### PR TITLE
Condense Switch statement and address bugs

### DIFF
--- a/Assets/greekLetterGrid.prefab
+++ b/Assets/greekLetterGrid.prefab
@@ -2402,6 +2402,10 @@ MonoBehaviour:
   - {fileID: 114971826483617316}
   - {fileID: 114321985018642524}
   - {fileID: 114441159678873686}
+  lettersText:
+  - {fileID: 102385812708459392}
+  - {fileID: 102011448713943798}
+  - {fileID: 102604604285972432}
   TwitchHelpMessage: Select a letter to move with !{0} select [1 | 2 | 3]. Use the
     arrow buttons with !{0} [press | move] [u | l | r | d]. You can string as many
     movements together in one command. Reset with !{0} reset. Submit with !{0} submit.

--- a/Assets/greekLetterGrid.unity
+++ b/Assets/greekLetterGrid.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0

--- a/Assets/greekLetterGridsScript.cs
+++ b/Assets/greekLetterGridsScript.cs
@@ -22,6 +22,8 @@ public class greekLetterGridsScript : MonoBehaviour
     string[] possibleLetters = { "A", "α", "B", "β", "Γ", "γ", "Δ", "δ", "Θ", "θ", "Λ", "λ", "Π", "π", "Σ", "σ", "Ω", "ω" };
     Color[] possibleColors = { new Color(1, 1, 1, 1), new Color(1, 0, 1, 1), new Color(1, 1, 0, 1), new Color(0, 1, 0, 1), new Color(0, 1, 1, 1) }; //Order of Colors: White, Magenta, Yellow, Green, Cyan
     float[] possibleXorZ = { -0.0375f, -0.0125f, 0.0125f, 0.0375f };
+    int[] letterIndex = new int[3];
+    int[] colorIndex = new int[3];
     /*
      *         X Axis Reference
      * -0.0375f, -0.0125f, 0.0125f, 0.0375f
@@ -37,25 +39,102 @@ public class greekLetterGridsScript : MonoBehaviour
     float letter2InitialZ;
     float letter3InitialX;
     float letter3InitialZ;
-    float letter1CurrentX;
-    float letter1CurrentZ;
-    float letter2CurrentX;
-    float letter2CurrentZ;
-    float letter3CurrentX;
-    float letter3CurrentZ;
     float letter1CorrectX;
     float letter1CorrectZ;
     float letter2CorrectX;
     float letter2CorrectZ;
     float letter3CorrectX;
     float letter3CorrectZ;
-    float selectedLetterX;
-    float selectedLetterZ;
+    float letter1CurrentX
+    {
+        get
+        {
+            return letters[0].transform.localPosition.x;
+        }
+    }
+    float letter1CurrentZ
+    {
+        get
+        {
+            return letters[0].transform.localPosition.z;
+        }
+    }
+    float letter2CurrentX
+    {
+        get
+        {
+            return letters[1].transform.localPosition.x;
+        }
+    }
+    float letter2CurrentZ
+    {
+        get
+        {
+            return letters[1].transform.localPosition.z;
+        }
+    }
+    float letter3CurrentX
+    {
+        get
+        {
+            return letters[2].transform.localPosition.x;
+        }
+    }
+    float letter3CurrentZ
+    {
+        get
+        {
+            return letters[2].transform.localPosition.z;
+        }
+    }
+    float selectedLetterX
+    {
+        get
+        {
+            return selectedLetter.transform.localPosition.x;
+        }
+    }
+    float selectedLetterZ
+    {
+        get
+        {
+            return selectedLetter.transform.localPosition.z;
+        }
+    }
+    float[] lettersInitialX
+    {
+        get
+        {
+            return new [] { letter1InitialX, letter2InitialX, letter3InitialX };
+        }
+    }
+    float[] lettersInitialZ
+    {
+        get
+        {
+            return new[] { letter1InitialZ, letter2InitialZ, letter3InitialZ };
+        }
+    }
+    float[] lettersCurrentX
+    {
+        get
+        {
+            return new[] { letter1CurrentX, letter2CurrentX, letter3CurrentX };
+        }
+    }
+    float[] lettersCurrentZ
+    {
+        get
+        {
+            return new[] { letter1CurrentZ, letter2CurrentZ, letter3CurrentZ };
+        }
+    }
     string[] oddDigits = { "1", "3", "5", "7", "9" };
     string[] evenDigits = { "2", "4", "6", "8", "0" };
     string[] primeNumbers = { "2", "3", "5", "7" };
     string[] uppercaseLetters = { "A", "B", "Γ", "Δ", "Θ", "Λ", "Π", "Σ", "Ω" };
     string[] lowercaseLetters = { "α", "β", "γ", "δ", "θ", "λ", "π", "σ", "ω" };
+    string[] LetterNames = { "Alpha", "Beta", "Gamma", "Delta", "Theta", "Lambda", "Pi", "Sigma", "Omega" };
 
     //Logging
     static int moduleIdCounter = 1;
@@ -103,56 +182,57 @@ public class greekLetterGridsScript : MonoBehaviour
         rightButton.OnInteract += delegate () { PressRightButton(); return false; };
         resetButton.OnInteract += delegate () { PressResetButton(); return false; };
         submitButton.OnInteract += delegate () { Submit(); return false; };
+        //Get Edgework Vars
+        GetComponent<KMBombModule>().OnActivate += delegate () { 
+            DefineEdgework();
+
+            string[] chosenOne = new string[3];
+            for (int i = 0; i < letterIndex.Length; i++)
+            {
+                if (letterIndex[i] % 2 == 0)
+                    chosenOne[i] = "an uppercase";
+                else
+                    chosenOne[i] = "a lowercase";
+                chosenOne[i] += string.Format(" {0}({1}) at {2}", LetterNames[letterIndex[i] / 2].ToLower(), possibleLetters[letterIndex[i]], CoordinateConversion(lettersInitialX[i], lettersInitialZ[i]));
+            }
+
+            DebugLog("The chosen characters are {0}, {1}, and {2}", chosenOne[0], chosenOne[1], chosenOne[2]);
+        };
     }
     // Use this for initialization
     void Start()
     {
         //Setting Randomized Colors & Letters
         //Holiday rules before full random
-        if (System.DateTime.Now.Month == 1 && System.DateTime.Now.Day == 31) //The Mega Man X OVA "The Day of Sigma" was released on 01/31/06. All letters are now uppercase sigma. I'm sorry. I'm a Mega Man fanboy.
+        for (int i = 0; i < letters.Length; i++)
         {
-            lettersText[0].text = possibleLetters[14];
-            lettersText[0].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-            lettersText[1].text = possibleLetters[14];
-            lettersText[1].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-            lettersText[2].text = possibleLetters[14];
-            lettersText[2].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-        }
-        else if (System.DateTime.Now.Month == 2 && System.DateTime.Now.Day == 14) //Happy Valentine's Day! All letters are now magenta.
-        {
-            lettersText[0].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            lettersText[0].color = possibleColors[1];
-            lettersText[1].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            lettersText[1].color = possibleColors[1];
-            lettersText[2].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            lettersText[2].color = possibleColors[1];
-        }
-        else if (System.DateTime.Now.Month == 3 && System.DateTime.Now.Day == 14) //Happy Pi Day! All letters are now upper/lowercase pi.
-        {
-            lettersText[0].text = possibleLetters[UnityEngine.Random.Range(12, 14)]; //Change the 12s back to possibleLetters.Length, as they are temporary.
-            lettersText[0].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-            lettersText[1].text = possibleLetters[UnityEngine.Random.Range(12, 14)];
-            lettersText[1].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-            lettersText[2].text = possibleLetters[UnityEngine.Random.Range(12, 14)];
-            lettersText[2].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-        }
-        else if (System.DateTime.Now.Month == 3 && System.DateTime.Now.Day == 17) //Happy St. Patrick's Day! All letters are now green.
-        {
-            lettersText[0].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            lettersText[0].color = possibleColors[3];
-            lettersText[1].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            lettersText[1].color = possibleColors[3];
-            lettersText[2].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            lettersText[2].color = possibleColors[3];
-        }
-        else //Sigh, nothing special today... Everything is randomized. :(
-        {
-            lettersText[0].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            lettersText[0].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-            lettersText[1].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            lettersText[1].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-            lettersText[2].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            lettersText[2].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
+            if (DateTime.Now.Month == 1 && DateTime.Now.Day == 31) //The Mega Man X OVA "The Day of Sigma" was released on 01/31/06. All letters are now uppercase sigma. I'm sorry. I'm a Mega Man fanboy.
+            {
+                colorIndex[i] = UnityEngine.Random.Range(0, possibleColors.Length);
+                letterIndex[i] = 14;
+            }
+            else if (DateTime.Now.Month == 2 && DateTime.Now.Day == 14) //Happy Valentine's Day! All letters are now magenta.
+            {
+                colorIndex[i] = 1;
+                letterIndex[i] = UnityEngine.Random.Range(0, possibleLetters.Length);
+            }
+            else if (DateTime.Now.Month == 3 && DateTime.Now.Day == 14) //Happy Pi Day! All letters are now upper/lowercase pi.
+            {
+                colorIndex[i] = UnityEngine.Random.Range(0, possibleColors.Length);
+                letterIndex[i] = UnityEngine.Random.Range(12, 14);
+            }
+            else if (DateTime.Now.Month == 3 && DateTime.Now.Day == 17)  //Happy St. Patrick's Day! All letters are now green.
+            {
+                colorIndex[i] = 3;
+                letterIndex[i] = UnityEngine.Random.Range(0, possibleLetters.Length);
+            }
+            else //Sigh, nothing special today... Everything is randomized. :(
+            {
+                colorIndex[i] = UnityEngine.Random.Range(0, possibleColors.Length);
+                letterIndex[i] = UnityEngine.Random.Range(0, possibleLetters.Length);
+            }
+            lettersText[i].color = possibleColors[colorIndex[i]];
+            lettersText[i].text = possibleLetters[letterIndex[i]];
         }
 
         //Setting Random Positions
@@ -167,9 +247,6 @@ public class greekLetterGridsScript : MonoBehaviour
         letter2InitialZ = letters[1].transform.localPosition.z;
         letter3InitialX = letters[2].transform.localPosition.x;
         letter3InitialZ = letters[2].transform.localPosition.z;
-
-        //Get Edgework Vars
-        DefineEdgework();
     }
 
     void DefineEdgework()
@@ -200,7 +277,7 @@ public class greekLetterGridsScript : MonoBehaviour
         bombEdgework.SNDIndicatorOff = bomb.IsIndicatorOff("SND") || bomb.IsIndicatorOff("IND");
         bombEdgework.CARIndicatorOff = bomb.IsIndicatorOff("CAR");
         bombEdgework.CLRIndicatorOn = bomb.IsIndicatorOn("CLR");
-        bombEdgework.SIGIndicatorOn = !bomb.IsIndicatorOn("SIG");
+        bombEdgework.SIGIndicatorOn = bomb.IsIndicatorOn("SIG");
         bombEdgework.DVINotRJ = bomb.IsPortPresent(Port.DVI) && !bomb.IsPortPresent(Port.RJ45);
         bombEdgework.RCAPresent = bomb.IsPortPresent(Port.StereoRCA);
         bombEdgework.ParallelPresent = bomb.IsPortPresent(Port.Parallel);
@@ -214,19 +291,15 @@ public class greekLetterGridsScript : MonoBehaviour
         bombEdgework.BatteryHolderCount = bomb.GetBatteryHolderCount();
     }
 
-    void Rules(int bombTime)
+    void Rules(int bombTime, int solvedModules, int strikes)
     {
         string[] lettersCorrect = new string[] { "", "", "" };
-        float[] lettersInitialX = new float[] { letter1InitialX, letter2InitialX, letter3InitialX };
-        float[] lettersInitialZ = new float[] { letter1InitialZ, letter2InitialZ, letter3InitialZ };
         string serialNumber = bombEdgework.SerialNumber;
         string serialNumberLastChar = serialNumber.Substring(serialNumber.Length - 1);
         //Shorthand to avoid typing bombEdgework everywhere
         Edgework b = bombEdgework;
         int batteryCount = b.DBatteryCount + b.AABatteryCount;
         int indicatorCount = b.OnIndicatorCount + b.OffIndicatorCount;
-        int solvedModules = bomb.GetSolvedModuleNames().Count;
-        int strikes = bomb.GetStrikes();
 
         //Check for each letter (e.g. if there is an uppercase alpha)
         for (int i = 0; i < letters.Length; i++)
@@ -268,7 +341,7 @@ public class greekLetterGridsScript : MonoBehaviour
 
                 case "α":
                     //If initially in column D...
-                    if (lettersInitialX[i] == 0.0375f)
+                    if (Mathf.Approximately(lettersInitialX[i], 0.0375f))
                     {
                         lettersCorrect[i] = CoordinateConversion(lettersInitialX[i] - 0.05f, lettersInitialZ[i]);
                         DebugLog("LOWERCASE ALPHA CONDITION: #1 (Initially in column D)");
@@ -307,7 +380,7 @@ public class greekLetterGridsScript : MonoBehaviour
                         DebugLog("UPPERCASE BETA CONDITION: #1 (this letter is cyan)");
                     }
                     //Otherwise, if this letter was initially found in row 3...
-                    else if (lettersInitialZ[i] == -0.0125f)
+                    else if (Mathf.Approximately(lettersInitialZ[i], -0.0125f))
                     {
                         lettersCorrect[i] = CoordinateConversion(lettersInitialX[i], lettersInitialZ[i] + 0.025f);
                         DebugLog("UPPERCASE BETA CONDITION: #2 (this letter was found in row 3)");
@@ -334,13 +407,13 @@ public class greekLetterGridsScript : MonoBehaviour
 
                 case "β":
                     //If this letter starts in A3...
-                    if (lettersInitialX[i] == -0.0375f && lettersInitialZ[i] == -0.0125f)
+                    if (CoordinateConversion(lettersInitialX[i], lettersInitialZ[i]) == "A3")
                     {
                         lettersCorrect[i] = "C4";
                         DebugLog("LOWERCASE BETA CONDITION: #1 (this letter started in A3)");
                     }
                     //Otherwise, if a letter is white and was initially found in the A column...
-                    else if ((letter1InitialX == -0.0375f && lettersText[0].color == new Color(1, 1, 1, 1)) || (letter2InitialX == -0.0375f && lettersText[1].color == new Color(1, 1, 1, 1)) || (letter3InitialX == -0.0375f && lettersText[2].color == new Color(1, 1, 1, 1)))
+                    else if ((Mathf.Approximately(letter1InitialX, -0.0375f) && lettersText[0].color == new Color(1, 1, 1, 1)) || (Mathf.Approximately(letter2InitialX, -0.0375f) && lettersText[1].color == new Color(1, 1, 1, 1)) || (Mathf.Approximately(letter3InitialX, -0.0375f) && lettersText[2].color == new Color(1, 1, 1, 1)))
                     {
                         lettersCorrect[i] = "A2";
                         DebugLog("LOWERCASE BETA CONDITION: #2 (white letter was found in the A column)");
@@ -385,7 +458,7 @@ public class greekLetterGridsScript : MonoBehaviour
                         DebugLog("UPPERCASE GAMMA CONDITION: #3 (all letters are magenta)");
                     }
                     //Otherwise, if this letter is cyan and starts in row 4...
-                    else if (lettersText[i].color == new Color(0, 1, 1, 1) && lettersInitialZ[i] == -0.0375f)
+                    else if (lettersText[i].color == new Color(0, 1, 1, 1) && Mathf.Approximately(lettersInitialZ[i], -0.0375f))
                     {
                         lettersCorrect[i] = CoordinateConversion(lettersInitialX[i], lettersInitialZ[i] + 0.05f);
                         DebugLog("UPPERCASE GAMMA CONDITION: #1 (this letter is cyan and started in row 4)");
@@ -412,9 +485,9 @@ public class greekLetterGridsScript : MonoBehaviour
                         DebugLog("LOWERCASE GAMMA CONDITION: #2 (this letter is NOT cyan and vowel detected)");
                     }
                     //Otherwise, if this letter starts in column C...
-                    else if (lettersInitialX[i] == 0.0125f)
+                    else if (Mathf.Approximately(lettersInitialX[i], 0.0125f))
                     {
-                        DebugLog("LOWERCASE GAMMA CONDITION: #2 (this letter starts in column C)");
+                        DebugLog("LOWERCASE GAMMA CONDITION: #3 (this letter starts in column C)");
                         if (int.Parse(serialNumberLastChar) <= 4) //If the last digit of the serial number is less than or equal to 4...
                         {
                             lettersCorrect[i] = CoordinateConversion(lettersInitialX[i] - 0.05f, lettersInitialZ[i]);
@@ -487,7 +560,7 @@ public class greekLetterGridsScript : MonoBehaviour
                         DebugLog("LOWERCASE DELTA CONDITION: #2 (solved modules + last digit > 10)");
                     }
                     //Otherwise, if any letter starts in A3...
-                    else if ((letter1InitialX == -0.0375f && letter1InitialZ == -0.0125f) || (letter2InitialX == -0.0375f && letter2InitialZ == -0.0125f) || (letter3InitialX == -0.0375f && letter3InitialZ == -0.0125f))
+                    else if (new string[] { CoordinateConversion(letter1InitialX, letter1InitialZ), CoordinateConversion(letter2InitialX, letter2InitialZ), CoordinateConversion(letter3InitialX, letter3InitialZ) }.Contains("A3"))
                     {
                         lettersCorrect[i] = "A3";
                         DebugLog("LOWERCASE DELTA CONDITION: #3 (a letter starts in A3)");
@@ -545,7 +618,7 @@ public class greekLetterGridsScript : MonoBehaviour
 
                 case "θ":
                     //If this letter starts in a row unique to the other 2 letters...
-                    if (lettersInitialZ[(i + 1) % letters.Length] != lettersInitialZ[i] && lettersInitialZ[(i + 2) % letters.Length] != lettersInitialZ[i])
+                    if (!lettersInitialZ[(i + 1) % letters.Length].ToString().Equals(lettersInitialZ[i].ToString()) && !lettersInitialZ[(i + 2) % letters.Length].ToString().Equals(lettersInitialZ[i].ToString()))
                     {
                         lettersCorrect[i] = "D3";
                         DebugLog("LOWERCASE THETA CONDITION: #1 (initial row is unique)");
@@ -671,7 +744,7 @@ public class greekLetterGridsScript : MonoBehaviour
                         DebugLog("UPPERCASE PI CONDITION: #3 (initial row is shared)");
                     }
                     //Otherwise, if this letter starts in one of the corners of the grid...
-                    else if (Math.Abs(lettersInitialX[i]) == 0.0375f && Math.Abs(lettersInitialZ[i]) == 0.0375f)
+                    else if (Mathf.Approximately(Math.Abs(lettersInitialX[i]), 0.0375f) && Mathf.Approximately(Math.Abs(lettersInitialZ[i]), 0.0375f))
                     {
                         lettersCorrect[i] = "A3";
                         DebugLog("UPPERCASE PI CONDITION: #4 (initially in corner)");
@@ -839,7 +912,7 @@ public class greekLetterGridsScript : MonoBehaviour
 
                 case "ω":
                     //If this letter starts in C4...
-                    if (lettersInitialX[i] == 0.0125f && lettersInitialZ[i] == -0.0375f)
+                    if (CoordinateConversion(lettersInitialX[i], lettersInitialZ[i]) == "C4")
                     {
                         lettersCorrect[i] = "B2";
                         DebugLog("LOWERCASE OMEGA CONDITION: #1 (this letter starts in C4)");
@@ -894,17 +967,17 @@ public class greekLetterGridsScript : MonoBehaviour
 
     string CoordinateConversion(float coordinateX, float coordinateZ)
     {
-         Dictionary<float, char> conversion = new Dictionary<float, char>
+        Dictionary<string, char> conversion = new Dictionary<string, char>
         {
-            { possibleXorZ[0], 'A' },
-            { possibleXorZ[1], 'B' },
-            { possibleXorZ[2], 'C' },
-            { possibleXorZ[3], 'D' }
+            { possibleXorZ[0].ToString(), 'A' },
+            { possibleXorZ[1].ToString(), 'B' },
+            { possibleXorZ[2].ToString(), 'C' },
+            { possibleXorZ[3].ToString(), 'D' }
         };
-        char X = conversion[coordinateX];
-        //'A' - 'A' = 0, 4 - 0 = 4 // 'D' - 'A' = 3, 4 - 3 = 1
-        int Z = 4 - (conversion[coordinateZ] - 'A');
-        return X.ToString() + Z.ToString();
+        char X = conversion[coordinateX.ToString()];
+        //4 - ('A' - 'A' = 0) = 4 // 4 - ('D' - 'A' = 3) = 1
+        int Z = 4 - (conversion[coordinateZ.ToString()] - 'A');
+        return string.Format("{0}{1}", X, Z);
     }
 
     //Arrow and Resest Button Interaction Methods
@@ -915,9 +988,9 @@ public class greekLetterGridsScript : MonoBehaviour
         if (selectedLetter != null && moduleSolved == false)
         {
             DebugLog("You pressed up! You deserve a cookie!");
-            if (selectedLetterZ != 0.0375f)
+            if (!Mathf.Approximately(selectedLetterZ, 0.0375f))
             {
-                selectedLetter.transform.localPosition = new Vector3(selectedLetterX, 0.013f, selectedLetterZ += 0.025f);
+                selectedLetter.transform.localPosition = new Vector3(selectedLetterX, 0.013f, selectedLetterZ + 0.025f);
             }
         }
     }
@@ -929,9 +1002,9 @@ public class greekLetterGridsScript : MonoBehaviour
         if (selectedLetter != null && moduleSolved == false)
         {
             DebugLog("You pressed down! You deserve a cookie!");
-            if (selectedLetterZ != -0.0375f)
+            if (!Mathf.Approximately(selectedLetterZ, -0.0375f))
             {
-                selectedLetter.transform.localPosition = new Vector3(selectedLetterX, 0.013f, selectedLetterZ -= 0.025f);
+                selectedLetter.transform.localPosition = new Vector3(selectedLetterX, 0.013f, selectedLetterZ - 0.025f);
             }
         }
     }
@@ -943,9 +1016,9 @@ public class greekLetterGridsScript : MonoBehaviour
         if (selectedLetter != null && moduleSolved == false)
         {
             DebugLog("You pressed left! You deserve a cookie!");
-            if (selectedLetterX != -0.0375f)
+            if (!Mathf.Approximately(selectedLetterX, -0.0375f))
             {
-                selectedLetter.transform.localPosition = new Vector3(selectedLetterX -= 0.025f, 0.013f, selectedLetterZ);
+                selectedLetter.transform.localPosition = new Vector3(selectedLetterX - 0.025f, 0.013f, selectedLetterZ);
             }
         }
     }
@@ -957,9 +1030,9 @@ public class greekLetterGridsScript : MonoBehaviour
         if (selectedLetter != null && moduleSolved == false)
         {
             DebugLog("You pressed right! You deserve a cookie!");
-            if (selectedLetterX != 0.0375f)
+            if (!Mathf.Approximately(selectedLetterX, 0.0375f))
             {
-                selectedLetter.transform.localPosition = new Vector3(selectedLetterX += 0.025f, 0.013f, selectedLetterZ);
+                selectedLetter.transform.localPosition = new Vector3(selectedLetterX + 0.025f, 0.013f, selectedLetterZ);
             }
         }
     }
@@ -975,9 +1048,10 @@ public class greekLetterGridsScript : MonoBehaviour
         else
         {
             DebugLog("You reset the module.");
-            letters[0].transform.localPosition = new Vector3(letter1InitialX, 0.013f, letter1InitialZ);
-            letters[1].transform.localPosition = new Vector3(letter2InitialX, 0.013f, letter2InitialZ);
-            letters[2].transform.localPosition = new Vector3(letter3InitialX, 0.013f, letter3InitialZ);
+            for (int i = 0; i < letters.Length; i++)
+            {
+                letters[i].transform.localPosition = new Vector3(lettersInitialX[i], 0.013f, lettersInitialZ[i]);
+            }
             selectedLetter = null;
         }
     }
@@ -995,7 +1069,7 @@ public class greekLetterGridsScript : MonoBehaviour
         int bombTime = (int)bomb.GetTime() / 60;
 
         //Rules based on user action
-        Rules(bombTime);
+        Rules(bombTime, bomb.GetSolvedModuleNames().Count, bomb.GetStrikes());
         if (noCondition && bombTime % 2 == 0)
         {
             GetComponent<KMBombModule>().HandleStrike();
@@ -1014,9 +1088,16 @@ public class greekLetterGridsScript : MonoBehaviour
         else
         {
             GetComponent<KMBombModule>().HandleStrike();
-            DebugLog("You failed. Try again, but do better! The correct coordinate for Letter 1 was " + CoordinateConversion(letter1CorrectX, letter1CorrectZ) + ". Your submitted coordinate was " + CoordinateConversion(letter1CurrentX, letter1CurrentZ));
-            DebugLog("The correct coordinate for Letter 2 was " + CoordinateConversion(letter2CorrectX, letter2CorrectZ) + ". Your submitted coordinate was " + CoordinateConversion(letter2CurrentX, letter2CurrentZ));
-            DebugLog("The correct coordinate for Letter 3 was " + CoordinateConversion(letter3CorrectX, letter3CorrectZ) + ". Your submitted coordinate was " + CoordinateConversion(letter3CurrentX, letter3CurrentZ));
+            float[] lettersCorrectX = { letter1CorrectX, letter2CorrectX, letter3CorrectX };
+            float[] lettersCorrectZ = { letter1CorrectZ, letter2CorrectZ, letter3CorrectZ };
+            string firstMessage = "You failed. Try again, but do better! ";
+            for (int i = 0; i < 3; i++)
+            {
+                string log = "The correct coordinate for Letter " + i + " was " + CoordinateConversion(lettersCorrectX[i], lettersCorrectZ[i]) + ". Your submitted coordinate was " + CoordinateConversion(lettersCurrentX[i], lettersCurrentZ[i]);
+                if (i == 0)
+                    log = firstMessage + log;
+                DebugLog(log);
+            }
             Start(); //Reset module with new letters in new positions.
 
         }
@@ -1028,20 +1109,7 @@ public class greekLetterGridsScript : MonoBehaviour
         GetComponent<KMAudio>().PlayGameSoundAtTransform(KMSoundOverride.SoundEffect.ButtonPress, transform);
         DebugLog("You pressed " + text);
         selectedLetter = letter;
-        selectedLetterX = selectedLetter.transform.localPosition.x;
-        selectedLetterZ = selectedLetter.transform.localPosition.z;
         selectedLetter.AddInteractionPunch();
-    }
-
-    // Update is called once per frame
-    void Update()
-    {
-        letter1CurrentX = letters[0].transform.localPosition.x;
-        letter1CurrentZ = letters[0].transform.localPosition.z;
-        letter2CurrentX = letters[1].transform.localPosition.x;
-        letter2CurrentZ = letters[1].transform.localPosition.z;
-        letter3CurrentX = letters[2].transform.localPosition.x;
-        letter3CurrentZ = letters[2].transform.localPosition.z;
     }
 
     void DebugLog(string log, params object[] args)
@@ -1112,5 +1180,56 @@ public class greekLetterGridsScript : MonoBehaviour
         }
 
         return null;
+    }
+
+    IEnumerator TwitchHandleForcedSolve()
+    {
+        //Make sure the time it takes to solve doesn't change the answer
+        var currentStrikes = bomb.GetStrikes();
+        var currentSolves = bomb.GetSolvedModuleNames().Count;
+        var currentMinute = (int)bomb.GetTime() / 60;
+
+        Rules(currentMinute, currentSolves, currentStrikes);
+        var lettersCorrectX = new[] { letter1CorrectX, letter2CorrectX, letter3CorrectX };
+        var lettersCorrectZ = new[] { letter1CorrectZ, letter2CorrectZ, letter3CorrectZ };
+        for (int i = 0; i < letters.Length; i++)
+        {
+            var step = 0;
+            letters[i].OnInteract();
+            var correctCoordinate = CoordinateConversion(lettersCorrectX[i], lettersCorrectZ[i]);
+            while(CoordinateConversion(lettersCurrentX[i], lettersCurrentZ[i]) != correctCoordinate)
+            {
+                if (lettersCurrentX[i].ToString() != lettersCorrectX[i].ToString())
+                {
+                    if (lettersCurrentX[i] < lettersCorrectX[i])
+                        rightButton.OnInteract();
+                    else
+                        leftButton.OnInteract();
+                }
+                else if (lettersCurrentZ[i].ToString() != lettersCorrectZ[i].ToString())
+                {
+                    if (lettersCurrentZ[i] < lettersCorrectZ[i])
+                        upButton.OnInteract();
+                    else
+                        downButton.OnInteract();
+                }
+            }
+            //Give the module a frame to actually move the letter
+            yield return null;
+            step++;
+            if (step > 16)
+            {
+                GetComponent<KMBombModule>().HandlePass();
+                Debug.LogFormat("<Greek Letter Grid #{0}> Autosolve could not be completed in a regular amount of steps, aborting.", moduleId);
+                yield break;
+            }
+        }
+        //Took too long to press buttons
+        if (currentMinute != (int)bomb.GetTime() / 60 || currentSolves != bomb.GetSolvedModuleNames().Count || currentStrikes != bomb.GetStrikes())
+        {
+            TwitchHandleForcedSolve();
+            yield break;
+        }
+        submitButton.OnInteract();
     }
 }

--- a/Assets/greekLetterGridsScript.cs
+++ b/Assets/greekLetterGridsScript.cs
@@ -85,6 +85,9 @@ public class greekLetterGridsScript : MonoBehaviour
         public int BatteryHolderCount;
     }
 
+    //Lowercase Theta condition for determining when the answer may be accepted
+    bool noCondition;
+
     void Awake()
     {
         moduleId = moduleIdCounter++;
@@ -165,16 +168,8 @@ public class greekLetterGridsScript : MonoBehaviour
         letter3InitialX = letters[2].transform.localPosition.x;
         letter3InitialZ = letters[2].transform.localPosition.z;
 
-        //Determine Solution
         //Get Edgework Vars
         DefineEdgework();
-        Rules();
-
-        //Verify the expected coordinate is the same as the reported coordinate (Debug code)
-        Debug.LogFormat("<Greek Letter Grid #{0}> First:{1}, Second:{2}, Third:{3}", moduleId,
-            CoordinateConversion(letter1CorrectX, letter1CorrectZ),
-            CoordinateConversion(letter2CorrectX, letter2CorrectZ),
-            CoordinateConversion(letter3CorrectX, letter3CorrectZ));
     }
 
     void DefineEdgework()
@@ -219,7 +214,7 @@ public class greekLetterGridsScript : MonoBehaviour
         bombEdgework.BatteryHolderCount = bomb.GetBatteryHolderCount();
     }
 
-    void Rules()
+    void Rules(int bombTime)
     {
         string[] lettersCorrect = new string[] { "", "", "" };
         float[] lettersInitialX = new float[] { letter1InitialX, letter2InitialX, letter3InitialX };
@@ -577,6 +572,7 @@ public class greekLetterGridsScript : MonoBehaviour
                     //Otherwise, if nothing applies...
                     else
                     {
+                        noCondition = true;
                         lettersCorrect[i] = "A2";
                         DebugLog("LOWERCASE THETA CONDITION: #5 (N/A)");
                     }
@@ -683,7 +679,7 @@ public class greekLetterGridsScript : MonoBehaviour
                     //Otherwise, if nothing applies...
                     else
                     {
-                        int zIndex = 3 - (((int)bomb.GetTime() / 60) % 4);
+                        int zIndex = 3 - (bombTime % 4);
                         lettersCorrect[i] = CoordinateConversion(possibleXorZ[0], possibleXorZ[zIndex]);
                         DebugLog("UPPERCASE PI CONDITION: #5 (N/A)");
                     }
@@ -996,8 +992,17 @@ public class greekLetterGridsScript : MonoBehaviour
             return;
         }
 
+        int bombTime = (int)bomb.GetTime() / 60;
+
         //Rules based on user action
-        Rules();
+        Rules(bombTime);
+        if (noCondition && bombTime % 2 == 0)
+        {
+            GetComponent<KMBombModule>().HandleStrike();
+            DebugLog("You failed. Try again, but do better! You submitted during an even minute while the final lowercase theta condition was active.");
+            Start();
+            return;
+        }
 
         if ((letter1CurrentX.ToString().Equals(letter1CorrectX.ToString()) && letter1CurrentZ.ToString().Equals(letter1CorrectZ.ToString())) && (letter2CurrentX.ToString().Equals(letter2CorrectX.ToString()) && letter2CurrentZ.ToString().Equals(letter2CorrectZ.ToString())) && (letter3CurrentX.ToString().Equals(letter3CorrectX.ToString()) && letter3CurrentZ.ToString().Equals(letter3CorrectZ.ToString()))) //Add letters 2 & 3 when done.
         {
@@ -1078,18 +1083,18 @@ public class greekLetterGridsScript : MonoBehaviour
             var btns = new List<KMSelectable>();
             var pieces = command.Trim().ToLowerInvariant().Split(new[] { ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);
 
-            for (int i = 1; i < pieces.Length; i++)
+            if (1 < pieces.Length)
             {
-                switch (pieces[i])
+                switch (pieces[1])
                 {
                     case "u": btns.Add(upButton); break;
                     case "l": btns.Add(leftButton); break;
                     case "r": btns.Add(rightButton); break;
                     case "d": btns.Add(downButton); break;
                     default:
-                        if (pieces[i].All(c => new[] { 'u', 'l', 'r', 'd' }.Contains(c)))
+                        if (pieces[1].All(c => new[] { 'u', 'l', 'r', 'd' }.Contains(c)))
                         {
-                            foreach(char c in pieces[i])
+                            foreach(char c in pieces[1])
                             {
                                 switch(c)
                                 {

--- a/Assets/greekLetterGridsScript.cs
+++ b/Assets/greekLetterGridsScript.cs
@@ -17,6 +17,7 @@ public class greekLetterGridsScript : MonoBehaviour
     public KMSelectable resetButton;
     public KMSelectable submitButton;
     public KMSelectable[] letters;
+    public TextMesh[] lettersText;
     private KMSelectable selectedLetter;
     string[] possibleLetters = { "A", "α", "B", "β", "Γ", "γ", "Δ", "δ", "Θ", "θ", "Λ", "λ", "Π", "π", "Σ", "σ", "Ω", "ω" };
     Color[] possibleColors = { new Color(1, 1, 1, 1), new Color(1, 0, 1, 1), new Color(1, 1, 0, 1), new Color(0, 1, 0, 1), new Color(0, 1, 1, 1) }; //Order of Colors: White, Magenta, Yellow, Green, Cyan
@@ -61,6 +62,14 @@ public class greekLetterGridsScript : MonoBehaviour
     private int moduleId;
     private bool moduleSolved = false;
 
+    //Edgework
+    private Edgework bombEdgework;
+    class Edgework
+    {
+        public string serialNumber;
+
+    }
+
     void Awake()
     {
         moduleId = moduleIdCounter++;
@@ -80,11 +89,6 @@ public class greekLetterGridsScript : MonoBehaviour
     // Use this for initialization
     void Start()
     {
-        //TextMesh variables so we only have three calls to GetComponent<TextMesh>
-        TextMesh[] lettersText = new TextMesh[3];
-        for (int i = 0; i < letters.Length; i++)
-            lettersText[i] = letters[i].GetComponent<TextMesh>();
-
         //Setting Randomized Colors & Letters
         //Holiday rules before full random
         if (System.DateTime.Now.Month == 1 && System.DateTime.Now.Day == 31) //The Mega Man X OVA "The Day of Sigma" was released on 01/31/06. All letters are now uppercase sigma. I'm sorry. I'm a Mega Man fanboy.
@@ -148,6 +152,19 @@ public class greekLetterGridsScript : MonoBehaviour
 
         //Determine Solution
         //Get Edgework Vars
+        DefineEdgework();
+        Rules();
+
+        //Verify the expected coordinate is the same as the reported coordinate (Debug code)
+        Debug.LogFormat("<Greek Letter Grid #{0}> First:{1}, Second:{2}, Third:{3}", moduleId,
+            CoordinateConversion(letter1CorrectX, letter1CorrectZ),
+            CoordinateConversion(letter2CorrectX, letter2CorrectZ),
+            CoordinateConversion(letter3CorrectX, letter3CorrectZ));
+    }
+
+    void DefineEdgework()
+    {
+        bombEdgework = new Edgework();
         string serialNumber = bomb.GetSerialNumber();
         string serialNumberLastChar = serialNumber.Substring(serialNumber.Length - 1);
         DebugLog("The last digit of the serial # is " + serialNumberLastChar);
@@ -168,10 +185,16 @@ public class greekLetterGridsScript : MonoBehaviour
         {
             DebugLog("The last digit of the serial # is COMPOSITE");
         }
+        bombEdgework.serialNumber = serialNumber;
+    }
 
+    void Rules()
+    {
         string[] lettersCorrect = new string[] { "", "", "" };
         float[] lettersInitialX = new float[] { letter1InitialX, letter2InitialX, letter3InitialX };
         float[] lettersInitialZ = new float[] { letter1InitialZ, letter2InitialZ, letter3InitialZ };
+        string serialNumber = bombEdgework.serialNumber;
+        string serialNumberLastChar = serialNumber.Substring(serialNumber.Length - 1);
 
         //Check for each letter (e.g. if there is an uppercase alpha)
         for (int i = 0; i < letters.Length; i++)
@@ -209,7 +232,7 @@ public class greekLetterGridsScript : MonoBehaviour
                         lettersCorrect[i] = CoordinateConversion(lettersInitialX[i], lettersInitialZ[i]);
                         DebugLog("UPPERCASE ALPHA CONDITION: #5 (N/A)");
                     }
-                break;
+                    break;
 
                 case "α":
                     //If initially in column D...
@@ -706,7 +729,7 @@ public class greekLetterGridsScript : MonoBehaviour
                             DebugLog("UPPERCASE SIGMA CONDITION: #5 (N/A)");
                         }
                     }
-                    
+
                     //Lowercase Sigma
                     else
                     {
@@ -834,11 +857,6 @@ public class greekLetterGridsScript : MonoBehaviour
         letter1CorrectZ = possibleXorZ[4 - (lettersCorrect[0][1] - '0')];
         letter2CorrectZ = possibleXorZ[4 - (lettersCorrect[1][1] - '0')];
         letter3CorrectZ = possibleXorZ[4 - (lettersCorrect[2][1] - '0')];
-        //Verify the expected coordinate is the same as the reported coordinate (Debug code)
-        Debug.LogFormat("<Greek Letter Grid #{0}> First:{1}, Second:{2}, Third:{3}", moduleId,
-            CoordinateConversion(letter1CorrectX, letter1CorrectZ),
-            CoordinateConversion(letter2CorrectX, letter2CorrectZ),
-            CoordinateConversion(letter3CorrectX, letter3CorrectZ));
     }
 
     string CoordinateConversion(float coordinateX, float coordinateZ)
@@ -940,6 +958,9 @@ public class greekLetterGridsScript : MonoBehaviour
         {
             return;
         }
+
+        //Rules based on user action
+        Rules();
 
         if ((letter1CurrentX.ToString().Equals(letter1CorrectX.ToString()) && letter1CurrentZ.ToString().Equals(letter1CorrectZ.ToString())) && (letter2CurrentX.ToString().Equals(letter2CorrectX.ToString()) && letter2CurrentZ.ToString().Equals(letter2CorrectZ.ToString())) && (letter3CurrentX.ToString().Equals(letter3CorrectX.ToString()) && letter3CurrentZ.ToString().Equals(letter3CorrectZ.ToString()))) //Add letters 2 & 3 when done.
         {

--- a/Assets/greekLetterGridsScript.cs
+++ b/Assets/greekLetterGridsScript.cs
@@ -67,7 +67,8 @@ public class greekLetterGridsScript : MonoBehaviour
         foreach (KMSelectable letter in letters)
         {
             KMSelectable pressedLetter = letter;
-            letter.OnInteract += delegate () { PressLetter(pressedLetter); return false; };
+            TextMesh text = letter.GetComponent<TextMesh>();
+            letter.OnInteract += delegate () { PressLetter(pressedLetter, text); return false; };
         }
         upButton.OnInteract += delegate () { PressUpButton(); return false; };
         downButton.OnInteract += delegate () { PressDownButton(); return false; };
@@ -79,52 +80,57 @@ public class greekLetterGridsScript : MonoBehaviour
     // Use this for initialization
     void Start()
     {
+        //TextMesh variables so we only have three calls to GetComponent<TextMesh>
+        TextMesh[] lettersText = new TextMesh[3];
+        for (int i = 0; i < letters.Length; i++)
+            lettersText[i] = letters[i].GetComponent<TextMesh>();
+
         //Setting Randomized Colors & Letters
         //Holiday rules before full random
         if (System.DateTime.Now.Month == 1 && System.DateTime.Now.Day == 31) //The Mega Man X OVA "The Day of Sigma" was released on 01/31/06. All letters are now uppercase sigma. I'm sorry. I'm a Mega Man fanboy.
         {
-            letters[0].GetComponent<TextMesh>().text = possibleLetters[14];
-            letters[0].GetComponent<TextMesh>().color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-            letters[1].GetComponent<TextMesh>().text = possibleLetters[14];
-            letters[1].GetComponent<TextMesh>().color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-            letters[2].GetComponent<TextMesh>().text = possibleLetters[14];
-            letters[2].GetComponent<TextMesh>().color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
+            lettersText[0].text = possibleLetters[14];
+            lettersText[0].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
+            lettersText[1].text = possibleLetters[14];
+            lettersText[1].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
+            lettersText[2].text = possibleLetters[14];
+            lettersText[2].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
         }
         else if (System.DateTime.Now.Month == 2 && System.DateTime.Now.Day == 14) //Happy Valentine's Day! All letters are now magenta.
         {
-            letters[0].GetComponent<TextMesh>().text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            letters[0].GetComponent<TextMesh>().color = possibleColors[1];
-            letters[1].GetComponent<TextMesh>().text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            letters[1].GetComponent<TextMesh>().color = possibleColors[1];
-            letters[2].GetComponent<TextMesh>().text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            letters[2].GetComponent<TextMesh>().color = possibleColors[1];
+            lettersText[0].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
+            lettersText[0].color = possibleColors[1];
+            lettersText[1].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
+            lettersText[1].color = possibleColors[1];
+            lettersText[2].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
+            lettersText[2].color = possibleColors[1];
         }
         else if (System.DateTime.Now.Month == 3 && System.DateTime.Now.Day == 14) //Happy Pi Day! All letters are now upper/lowercase pi.
         {
-            letters[0].GetComponent<TextMesh>().text = possibleLetters[UnityEngine.Random.Range(12, 14)]; //Change the 12s back to possibleLetters.Length, as they are temporary.
-            letters[0].GetComponent<TextMesh>().color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-            letters[1].GetComponent<TextMesh>().text = possibleLetters[UnityEngine.Random.Range(12, 14)];
-            letters[1].GetComponent<TextMesh>().color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-            letters[2].GetComponent<TextMesh>().text = possibleLetters[UnityEngine.Random.Range(12, 14)];
-            letters[2].GetComponent<TextMesh>().color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
+            lettersText[0].text = possibleLetters[UnityEngine.Random.Range(12, 14)]; //Change the 12s back to possibleLetters.Length, as they are temporary.
+            lettersText[0].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
+            lettersText[1].text = possibleLetters[UnityEngine.Random.Range(12, 14)];
+            lettersText[1].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
+            lettersText[2].text = possibleLetters[UnityEngine.Random.Range(12, 14)];
+            lettersText[2].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
         }
         else if (System.DateTime.Now.Month == 3 && System.DateTime.Now.Day == 17) //Happy St. Patrick's Day! All letters are now green.
         {
-            letters[0].GetComponent<TextMesh>().text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            letters[0].GetComponent<TextMesh>().color = possibleColors[3];
-            letters[1].GetComponent<TextMesh>().text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            letters[1].GetComponent<TextMesh>().color = possibleColors[3];
-            letters[2].GetComponent<TextMesh>().text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            letters[2].GetComponent<TextMesh>().color = possibleColors[3];
+            lettersText[0].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
+            lettersText[0].color = possibleColors[3];
+            lettersText[1].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
+            lettersText[1].color = possibleColors[3];
+            lettersText[2].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
+            lettersText[2].color = possibleColors[3];
         }
         else //Sigh, nothing special today... Everything is randomized. :(
         {
-            letters[0].GetComponent<TextMesh>().text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            letters[0].GetComponent<TextMesh>().color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-            letters[1].GetComponent<TextMesh>().text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            letters[1].GetComponent<TextMesh>().color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
-            letters[2].GetComponent<TextMesh>().text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
-            letters[2].GetComponent<TextMesh>().color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
+            lettersText[0].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
+            lettersText[0].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
+            lettersText[1].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
+            lettersText[1].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
+            lettersText[2].text = possibleLetters[UnityEngine.Random.Range(0, possibleLetters.Length)];
+            lettersText[2].color = possibleColors[UnityEngine.Random.Range(0, possibleColors.Length)];
         }
 
         //Setting Random Positions
@@ -144,539 +150,163 @@ public class greekLetterGridsScript : MonoBehaviour
         //Get Edgework Vars
         string serialNumber = bomb.GetSerialNumber();
         string serialNumberLastChar = serialNumber.Substring(serialNumber.Length - 1);
-        Debug.Log("The last digit of the serial # is " + serialNumberLastChar);
+        DebugLog("The last digit of the serial # is " + serialNumberLastChar);
         if (oddDigits.Contains(serialNumberLastChar))
         {
-            Debug.Log("The last digit of the serial # is ODD");
+            DebugLog("The last digit of the serial # is ODD");
         }
         else
         {
-            Debug.Log("The last digit of the serial # is EVEN");
+            DebugLog("The last digit of the serial # is EVEN");
         }
 
         if (primeNumbers.Contains(serialNumberLastChar))
         {
-            Debug.Log("The last digit of the serial # is PRIME");
+            DebugLog("The last digit of the serial # is PRIME");
         }
         else
         {
-            Debug.Log("The last digit of the serial # is COMPOSITE");
+            DebugLog("The last digit of the serial # is COMPOSITE");
         }
+
+        string[] lettersCorrect = new string[] { "", "", "" };
+        float[] lettersInitialX = new float[] { letter1InitialX, letter2InitialX, letter3InitialX };
+        float[] lettersInitialZ = new float[] { letter1InitialZ, letter2InitialZ, letter3InitialZ };
 
         //Check for each letter (e.g. if there is an uppercase alpha)
         for (int i = 0; i < letters.Length; i++)
         {
-            switch (letters[i].GetComponent<TextMesh>().text)
+            switch (lettersText[i].text)
             {
                 case "A":
                     //If there is a lowercase sigma...
-                    if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text == "σ" || letters[(i + 2) % letters.Length].GetComponent<TextMesh>().text == "σ")
+                    if (lettersText[(i + 1) % letters.Length].text == "σ" || lettersText[(i + 2) % letters.Length].text == "σ")
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #1 (Lowercase Sigma Detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #1 (Lowercase Sigma Detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #1 (Lowercase Sigma Detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A4";
+                        DebugLog("UPPERCASE ALPHA CONDITION: #1 (Lowercase Sigma Detected)");
                     }
                     //Otherwise, if the letter is yellow...
-                    else if (letters[i].GetComponent<TextMesh>().color == new Color(1, 1, 0, 1))
+                    else if (lettersText[i].color == new Color(1, 1, 0, 1))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #2 (This letter is yellow)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #2 (This letter is yellow)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #2 (This letter is yellow)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B1";
+                        DebugLog("UPPERCASE ALPHA CONDITION: #2 (This letter is yellow)");
                     }
                     //Otherwise of there is an unlit SND or an unlit IND...
                     else if (bomb.IsIndicatorOff("SND") || bomb.IsIndicatorOff("IND"))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #3 (Unlit SND or IND detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #3 (Unlit SND or IND detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #3 (Unlit SND or IND detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D3";
+                        DebugLog("UPPERCASE ALPHA CONDITION: #3 (Unlit SND or IND detected)");
                     }
                     //Otherwise if the other 2 letters are identical colors...
-                    else if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color == letters[(i + 2) % letters.Length].GetComponent<TextMesh>().color)
+                    else if (lettersText[(i + 1) % letters.Length].color == lettersText[(i + 2) % letters.Length].color)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #4 (Other 2 letters are identical colors)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #4 (Other 2 letters are identical colors)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #4 (Other 2 letters are identical colors)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C3";
+                        DebugLog("UPPERCASE ALPHA CONDITION: #4 (Other 2 letters are identical colors)");
                     }
                     //Otherwise if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = letter1InitialX;
-                                letter1CorrectZ = letter1InitialZ;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = letter2InitialX;
-                                letter2CorrectZ = letter2InitialZ;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = letter3InitialX;
-                                letter3CorrectZ = letter3InitialZ;
-                                Debug.Log("UPPERCASE ALPHA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = CoordinateConversion(lettersInitialX[i], lettersInitialZ[i]);
+                        DebugLog("UPPERCASE ALPHA CONDITION: #5 (N/A)");
                     }
-                    break;
+                break;
 
                 case "α":
                     //If initially in column D...
-                    if ((i == 0 && letter1InitialX == 0.0375f) || (i == 1 && letter2InitialX == 0.0375f) || (i == 2 && letter3InitialX == 0.0375f))
+                    if (lettersInitialX[i] == 0.0375f)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = letter1InitialX -= 0.05f;
-                                letter1CorrectZ = letter1InitialZ;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #1 (Initially in column D)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = letter2InitialX -= 0.05f;
-                                letter2CorrectZ = letter2InitialZ;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #1 (Initially in column D)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = letter3InitialX -= 0.05f;
-                                letter3CorrectZ = letter3InitialZ;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #1 (Initially in column D)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = CoordinateConversion(lettersInitialX[i] - 0.05f, lettersInitialZ[i]);
+                        DebugLog("LOWERCASE ALPHA CONDITION: #1 (Initially in column D)");
                     }
                     //Otherwise if 3 or more batteries...
                     else if (bomb.GetBatteryCount() >= 3)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #2 (3+ batteries detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #2 (3+ batteries detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #2 (3+ batteries detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D1";
+                        DebugLog("LOWERCASE ALPHA CONDITION: #2 (3+ batteries detected)");
                     }
                     //Otherwise, if this letter is green and an anycase delta is on the module...
-                    else if (letters[i].GetComponent<TextMesh>().color == new Color(0, 0, 1, 1) && (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text == "Δ" || letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text == "δ" || letters[(i + 2) % letters.Length].GetComponent<TextMesh>().text == "Δ" || letters[(i + 2) % letters.Length].GetComponent<TextMesh>().text == "δ"))
+                    else if (lettersText[i].color == new Color(0, 0, 1, 1) && (lettersText[(i + 1) % letters.Length].text == "Δ" || lettersText[(i + 1) % letters.Length].text == "δ" || lettersText[(i + 2) % letters.Length].text == "Δ" || lettersText[(i + 2) % letters.Length].text == "δ"))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #3 (this letter is green & delta detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #3 (this letter is green & delta detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #3 (this letter is green & delta detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C2";
+                        DebugLog("LOWERCASE ALPHA CONDITION: #3 (this letter is green & delta detected)");
                     }
                     //Otherwise, if there's a lit CLR...
                     else if (bomb.IsIndicatorOn("CLR"))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #4 (lit CLR detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #4 (lit CLR detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #4 (lit CLR detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A1";
+                        DebugLog("LOWERCASE ALPHA CONDITION: #4 (lit CLR detected)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE ALPHA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A3";
+                        DebugLog("LOWERCASE ALPHA CONDITION: #5 (N/A)");
                     }
                     break;
 
                 case "B":
                     //If this letter is cyan...
-                    if (letters[i].GetComponent<TextMesh>().color == new Color(0, 1, 1, 1))
+                    if (lettersText[i].color == new Color(0, 1, 1, 1))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #1 (this letter is cyan)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #1 (this letter is cyan)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #1 (this letter is cyan)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D1";
+                        DebugLog("UPPERCASE BETA CONDITION: #1 (this letter is cyan)");
                     }
                     //Otherwise, if this letter was initially found in row 3...
-                    else if ((i == 0 && letter1InitialZ == -0.0125f) || (i == 1 && letter2InitialZ == -0.0125f) || (i == 2 && letter3InitialZ == -0.0125f))
+                    else if (lettersInitialZ[i] == -0.0125f)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = letter1InitialX;
-                                letter1CorrectZ = letter1InitialZ += 0.025f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #2 (this letter was found in row 3)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = letter2InitialX;
-                                letter2CorrectZ = letter2InitialZ += 0.025f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #2 (this letter was found in row 3)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = letter3InitialX;
-                                letter3CorrectZ = letter3InitialZ += 0.025f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #2 (this letter was found in row 3)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = CoordinateConversion(lettersInitialX[i], lettersInitialZ[i] + 0.025f);
+                        DebugLog("UPPERCASE BETA CONDITION: #2 (this letter was found in row 3)");
                     }
                     //Otherwise, if the last char of serial # is odd & there is a lowercase letter...
-                    else if (oddDigits.Contains(serialNumberLastChar) && (lowercaseLetters.Contains(letters[i].GetComponent<TextMesh>().text) || lowercaseLetters.Contains(letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text) || lowercaseLetters.Contains(letters[(i + 2) % letters.Length].GetComponent<TextMesh>().text)))
+                    else if (oddDigits.Contains(serialNumberLastChar) && (lowercaseLetters.Contains(lettersText[(i + 1) % letters.Length].text) || lowercaseLetters.Contains(lettersText[(i + 2) % letters.Length].text)))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #3 (last digit of the serial number is odd and there is a lowercase letter)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #3 (last digit of the serial number is odd and there is a lowercase letter)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #3 (last digit of the serial number is odd and there is a lowercase letter)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B4";
+                        DebugLog("UPPERCASE BETA CONDITION: #3 (last digit of the serial number is odd and there is a lowercase letter)");
                     }
                     //Otherwise, if there is a a green uppercase letter...
-                    else if ((letters[i].GetComponent<TextMesh>().color == new Color(0, 1, 0, 1)) || (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color == new Color(0, 1, 0, 1) && uppercaseLetters.Contains(letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text)) || (letters[(i + 2) % letters.Length].GetComponent<TextMesh>().color == new Color(0, 1, 0, 1) && uppercaseLetters.Contains(letters[(i + 2) % letters.Length].GetComponent<TextMesh>().text)))
+                    else if ((lettersText[i].color == new Color(0, 1, 0, 1)) || (lettersText[(i + 1) % letters.Length].color == new Color(0, 1, 0, 1) && uppercaseLetters.Contains(lettersText[(i + 1) % letters.Length].text)) || (lettersText[(i + 2) % letters.Length].color == new Color(0, 1, 0, 1) && uppercaseLetters.Contains(lettersText[(i + 2) % letters.Length].text)))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #4 (green uppercase detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #4 (green uppercase detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #4 (green uppercase detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C2";
+                        DebugLog("UPPERCASE BETA CONDITION: #4 (green uppercase detected)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE BETA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C4";
+                        DebugLog("UPPERCASE BETA CONDITION: #5 (N/A)");
                     }
                     break;
 
                 case "β":
                     //If this letter starts in A3...
-                    if ((i == 0 && letter1InitialX == -0.0375f && letter1InitialZ == -0.0125f) || (i == 1 && letter2InitialX == -0.0375f && letter2InitialZ == -0.0125f) || (i == 2 && letter3InitialX == -0.0375f && letter3InitialZ == -0.0125f))
+                    if (lettersInitialX[i] == -0.0375f && lettersInitialZ[i] == -0.0125f)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #1 (this letter started in A3)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #1 (this letter started in A3)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #1 (this letter started in A3)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C4";
+                        DebugLog("LOWERCASE BETA CONDITION: #1 (this letter started in A3)");
                     }
                     //Otherwise, if a letter is white and was initially found in the A column...
-                    else if ((letter1InitialX == -0.0375f && letters[0].GetComponent<TextMesh>().color == new Color(1, 1, 1, 1)) || (letter2InitialX == -0.0375f && letters[1].GetComponent<TextMesh>().color == new Color(1, 1, 1, 1)) || (letter3InitialX == -0.0375f && letters[2].GetComponent<TextMesh>().color == new Color(1, 1, 1, 1)))
+                    else if ((letter1InitialX == -0.0375f && lettersText[0].color == new Color(1, 1, 1, 1)) || (letter2InitialX == -0.0375f && lettersText[1].color == new Color(1, 1, 1, 1)) || (letter3InitialX == -0.0375f && lettersText[2].color == new Color(1, 1, 1, 1)))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #2 (white letter was found in the A column)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #2 (white letter was found in the A column)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #2 (white letter was found in the A column)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A2";
+                        DebugLog("LOWERCASE BETA CONDITION: #2 (white letter was found in the A column)");
                     }
                     //Otherwise, if this letter is magenta or cyan...
-                    else if (letters[i].GetComponent<TextMesh>().color == new Color(1, 0, 1, 1) || letters[i].GetComponent<TextMesh>().color == new Color(0, 1, 1, 1))
+                    else if (lettersText[i].color == new Color(1, 0, 1, 1) || lettersText[i].color == new Color(0, 1, 1, 1))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #3 (this letter is magenta/cyan)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #3 (this letter is magenta/cyan)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #3 (this letter is magenta/cyan)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D4";
+                        DebugLog("LOWERCASE BETA CONDITION: #3 (this letter is magenta/cyan)");
                     }
                     //Otherwise, if there is a DVI and no RJ45...
                     else if (bomb.IsPortPresent(Port.DVI) && !bomb.IsPortPresent(Port.RJ45))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #4 (DVI and no RJ45 detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #4 (DVI and no RJ45 detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #4 (DVI and no RJ45 detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B2";
+                        DebugLog("LOWERCASE BETA CONDITION: #4 (DVI and no RJ45 detected)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE BETA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B1";
+                        DebugLog("LOWERCASE BETA CONDITION: #5 (N/A)");
                     }
                     break;
 
@@ -684,282 +314,74 @@ public class greekLetterGridsScript : MonoBehaviour
                     //If the serial number contains a letter that is in the first half of the alphabet...
                     if (bomb.GetSerialNumberLetters().Any(x => x == 'A' || x == 'B' || x == 'C' || x == 'D' || x == 'E' || x == 'F' || x == 'G' || x == 'H' || x == 'I' || x == 'J' || x == 'K' || x == 'L' || x == 'M'))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #1 (A letter in the serial number is found in the first half of the English Alphabet)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #1 (A letter in the serial number is found in the first half of the English Alphabet)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #1 (A letter in the serial number is found in the first half of the English Alphabet)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D2";
+                        DebugLog("UPPERCASE GAMMA CONDITION: #1 (A letter in the serial number is found in the first half of the English Alphabet)");
                     }
                     //Otherwise, if there is an empty port plate...
                     else if (bomb.GetPortPlates().Any(x => x.Length == 0))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #2 (empty port plate detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #2 (empty port plate detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #2 (empty port plate detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C2";
+                        DebugLog("UPPERCASE GAMMA CONDITION: #2 (empty port plate detected)");
                     }
                     //Otherwise, if all letters are magenta...
-                    else if (letters[i].GetComponent<TextMesh>().color == new Color(1, 0, 1, 1) && letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color == new Color(1, 0, 1, 1) && letters[(i + 2) % letters.Length].GetComponent<TextMesh>().color == new Color(1, 0, 1, 1))
+                    else if (lettersText.All(x => x.color == new Color(1, 0, 1, 1)))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #3 (all letters are magenta)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #3 (all letters are magenta)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #3 (all letters are magenta)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A1";
+                        DebugLog("UPPERCASE GAMMA CONDITION: #3 (all letters are magenta)");
                     }
                     //Otherwise, if this letter is cyan and starts in row 4...
-                    else if (letters[i].GetComponent<TextMesh>().color == new Color(0, 1, 1, 1) && ((i == 0 && letter1CurrentZ == -0.0375f) || (i == 1 && letter2CurrentZ == -0.0375f) || (i == 2 && letter3CurrentZ == -0.0375f)))
+                    else if (lettersText[i].color == new Color(0, 1, 1, 1) && lettersInitialZ[i] == -0.0375f)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = letter1InitialX;
-                                letter1CorrectZ = letter1InitialZ += 0.05f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #1 (this letter is cyan and started in row 4)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = letter2InitialX;
-                                letter2CorrectZ = letter2InitialZ += 0.05f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #1 (this letter is cyan and started in row 4)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = letter3InitialX;
-                                letter3CorrectZ = letter3InitialZ += 0.05f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #1 (this letter is cyan and started in row 4)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = CoordinateConversion(lettersInitialX[i], lettersInitialZ[i] + 0.05f);
+                        DebugLog("UPPERCASE GAMMA CONDITION: #1 (this letter is cyan and started in row 4)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE GAMMA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A2";
+                        DebugLog("UPPERCASE GAMMA CONDITION: #5 (N/A)");
                     }
                     break;
 
                 case "γ":
                     //If anycase anycolor theta is present...
-                    if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text == "Θ" || letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text == "θ" || letters[(i + 2) % letters.Length].GetComponent<TextMesh>().text == "Θ" || letters[(i + 2) % letters.Length].GetComponent<TextMesh>().text == "θ")
+                    if (lettersText[(i + 1) % letters.Length].text == "Θ" || lettersText[(i + 1) % letters.Length].text == "θ" || lettersText[(i + 2) % letters.Length].text == "Θ" || lettersText[(i + 2) % letters.Length].text == "θ")
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE GAMMA CONDITION: #1 (theta detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE GAMMA CONDITION: #1 (theta detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE GAMMA CONDITION: #1 (theta detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C1";
+                        DebugLog("LOWERCASE GAMMA CONDITION: #1 (theta detected)");
                     }
                     //Otherwise, if not cyan and serial number contains vowel...
-                    else if (letters[i].GetComponent<TextMesh>().color != new Color(0, 1, 1, 1) && bomb.GetSerialNumberLetters().Any(x => x == 'A' || x == 'E' || x == 'I' || x == 'O' || x == 'U'))
+                    else if (lettersText[i].color != new Color(0, 1, 1, 1) && bomb.GetSerialNumberLetters().Any(x => x == 'A' || x == 'E' || x == 'I' || x == 'O' || x == 'U'))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE GAMMA CONDITION: #2 (this letter is NOT cyan and vowel detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE GAMMA CONDITION: #2 (this letter is NOT cyan and vowel detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE GAMMA CONDITION: #2 (this letter is NOT cyan and vowel detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B3";
+                        DebugLog("LOWERCASE GAMMA CONDITION: #2 (this letter is NOT cyan and vowel detected)");
                     }
                     //Otherwise, if this letter starts in column C...
-                    else if ((i == 0 && letter1InitialX == 0.0125f) || (i == 1 && letter2InitialX == 0.0125f) || (i == 2 && letter3InitialX == 0.0125f))
+                    else if (lettersInitialX[i] == 0.0125f)
                     {
+                        DebugLog("LOWERCASE GAMMA CONDITION: #2 (this letter starts in column C)");
                         if (int.Parse(serialNumberLastChar) <= 4) //If the last digit of the serial number is less than or equal to 4...
                         {
-                            switch (i)
-                            {
-                                case 0:
-                                    letter1CorrectX = letter1InitialX -= 0.05f;
-                                    letter1CorrectZ = letter1InitialZ;
-                                    Debug.Log("LOWERCASE GAMMA CONDITION: #2A (this letter starts in column C & the last digit of the serial number is less than or equal to 4.)");
-                                    Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                    break;
-                                case 1:
-                                    letter2CorrectX = letter2InitialX -= 0.05f;
-                                    letter2CorrectZ = letter2InitialZ;
-                                    Debug.Log("LOWERCASE GAMMA CONDITION: #2A (this letter starts in column C & the last digit of the serial number is less than or equal to 4.)");
-                                    Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                    break;
-                                case 2:
-                                    letter3CorrectX = letter3InitialX -= 0.05f;
-                                    letter3CorrectZ = letter3InitialZ;
-                                    Debug.Log("LOWERCASE GAMMA CONDITION: #2A (this letter starts in column C & the last digit of the serial number is less than or equal to 4.)");
-                                    Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                    break;
-                            }
+                            lettersCorrect[i] = CoordinateConversion(lettersInitialX[i] - 0.05f, lettersInitialZ[i]);
+                            DebugLog("The last digit of the serial number is less than or equal to 4.");
                         }
                         else //If the last digit of the serial number is greater than 4...
                         {
-                            switch (i)
-                            {
-                                case 0:
-                                    letter1CorrectX = letter1InitialX -= 0.025f;
-                                    letter1CorrectZ = letter1InitialZ;
-                                    Debug.Log("LOWERCASE GAMMA CONDITION: #2B (this letter starts in column C & the last digit of the serial number is greater than 4.)");
-                                    Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                    break;
-                                case 1:
-                                    letter2CorrectX = letter2InitialX -= 0.025f;
-                                    letter2CorrectZ = letter2InitialZ;
-                                    Debug.Log("LOWERCASE GAMMA CONDITION: #2B (this letter starts in column C & the last digit of the serial number is greater than 4.)");
-                                    Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                    break;
-                                case 2:
-                                    letter3CorrectX = letter3InitialX -= 0.025f;
-                                    letter3CorrectZ = letter3InitialZ;
-                                    Debug.Log("LOWERCASE GAMMA CONDITION: #2B (this letter starts in column C & the last digit of the serial number is greater than 4.)");
-                                    Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                    break;
-                            }
+                            lettersCorrect[i] = CoordinateConversion(lettersInitialX[i] - 0.025f, lettersInitialZ[i]);
+                            DebugLog("The last digit of the serial number is greater than 4.");
                         }
                     }
                     //Otherwise, if the last digit of the serial number is prime...
                     else if (primeNumbers.ToString().Contains(serialNumberLastChar))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE GAMMA CONDITION: #4 (last digit of the serial number is prime)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE GAMMA CONDITION: #4 (last digit of the serial number is prime)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE GAMMA CONDITION: #4 (last digit of the serial number is prime)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D3";
+                        DebugLog("LOWERCASE GAMMA CONDITION: #4 (last digit of the serial number is prime)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE GAMMA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE GAMMA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE GAMMA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D4";
+                        DebugLog("LOWERCASE GAMMA CONDITION: #5 (N/A)");
                     }
                     break;
 
@@ -967,646 +389,136 @@ public class greekLetterGridsScript : MonoBehaviour
                     //If there is a stereo RCA port...
                     if (bomb.IsPortPresent(Port.StereoRCA))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #1 (stereo RCA detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #1 (stereo RCA detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #1 (stereo RCA detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B2";
+                        DebugLog("UPPERCASE DELTA CONDITION: #1 (stereo RCA detected)");
                     }
                     //Otherwise, if the number of batteries is greater than the last digit of the serial number...
                     else if (bomb.GetBatteryCount() > int.Parse(serialNumberLastChar))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #2 (battery count > last digit in serial number)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #2 (battery count > last digit in serial number)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #2 (battery count > last digit in serial number)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A3";
+                        DebugLog("UPPERCASE DELTA CONDITION: #2 (battery count > last digit in serial number)");
                     }
                     //Otherwise, if you have solved half or over half of the modules on this bomb...
-                    else if (letters[i].GetComponent<TextMesh>().color != new Color(1, 0, 1, 1) && letters[i].GetComponent<TextMesh>().color != new Color(1, 1, 0, 1))
+                    else if (lettersText[i].color != new Color(1, 0, 1, 1) && lettersText[i].color != new Color(1, 1, 0, 1))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #3 (this letter is neither yellow nor magenta)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #3 (this letter is neither yellow nor magenta)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #3 (this letter is neither yellow nor magenta)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D4";
+                        DebugLog("UPPERCASE DELTA CONDITION: #3 (this letter is neither yellow nor magenta)");
                     }
                     //Otherwise, if there is a green lowercase omega...
-                    else if ((letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text == "ω" && letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color == new Color(0, 1, 0, 1)) || (letters[(i + 2) % letters.Length].GetComponent<TextMesh>().text == "ω" && letters[(i + 2) % letters.Length].GetComponent<TextMesh>().color == new Color(0, 1, 0, 1)))
+                    else if ((lettersText[(i + 1) % letters.Length].text == "ω" && lettersText[(i + 1) % letters.Length].color == new Color(0, 1, 0, 1)) || (lettersText[(i + 2) % letters.Length].text == "ω" && lettersText[(i + 2) % letters.Length].color == new Color(0, 1, 0, 1)))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #4 (green lowercase omega detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #4 (green lowercase omega detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #4 (green lowercase omega detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A1";
+                        DebugLog("UPPERCASE DELTA CONDITION: #4 (green lowercase omega detected)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE DELTA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C1";
+                        DebugLog("UPPERCASE DELTA CONDITION: #5 (N/A)");
                     }
                     break;
 
                 case "δ":
                     //If this is the only lowercase letter on the module...
-                    if (uppercaseLetters.Contains(letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text) && uppercaseLetters.Contains(letters[(i + 2) % letters.Length].GetComponent<TextMesh>().text))
+                    if (uppercaseLetters.Contains(lettersText[(i + 1) % letters.Length].text) && uppercaseLetters.Contains(lettersText[(i + 2) % letters.Length].text))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #1 (this letter is the only lowercase letter on the module)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #1 (this letter is the only lowercase letter on the module)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #1 (this letter is the only lowercase letter on the module)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C3";
+                        DebugLog("LOWERCASE DELTA CONDITION: #1 (this letter is the only lowercase letter on the module)");
                     }
                     //Otherwise, if the number of solved modules + the last digit of the serial number > 10...
                     else if (bomb.GetSolvedModuleNames().Count + int.Parse(serialNumberLastChar) > 10)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #2 (solved modules + last digit > 10)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #2 (solved modules + last digit > 10)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #2 (solved modules + last digit > 10)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B3";
+                        DebugLog("LOWERCASE DELTA CONDITION: #2 (solved modules + last digit > 10)");
                     }
                     //Otherwise, if any letter starts in A3...
                     else if ((letter1InitialX == -0.0375f && letter1InitialZ == -0.0125f) || (letter2InitialX == -0.0375f && letter2InitialZ == -0.0125f) || (letter3InitialX == -0.0375f && letter3InitialZ == -0.0125f))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #3 (a letter starts in A3)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #3 (a letter starts in A3)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #3 (a letter starts in A3)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A3";
+                        DebugLog("LOWERCASE DELTA CONDITION: #3 (a letter starts in A3)");
                     }
                     //Otherwise, if this letter is the only cyan letter on the module...
-                    else if (letters[i].GetComponent<TextMesh>().color == new Color(0, 1, 1, 1) && (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color != new Color(0, 1, 1, 1)) && (letters[(i + 2) % letters.Length].GetComponent<TextMesh>().color != new Color(0, 1, 1, 1)))
+                    else if (lettersText[i].color == new Color(0, 1, 1, 1) && (lettersText[(i + 1) % letters.Length].color != new Color(0, 1, 1, 1)) && (lettersText[(i + 2) % letters.Length].color != new Color(0, 1, 1, 1)))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #4 (this letter is cyan and the other letters are not)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #4 (this letter is cyan and the other letters are not)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #4 (this letter is cyan and the other letters are not)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B4";
+                        DebugLog("LOWERCASE DELTA CONDITION: #4 (this letter is cyan and the other letters are not)");
                     }
                     //Otherwise if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE DELTA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C2";
+                        DebugLog("LOWERCASE DELTA CONDITION: #5 (N/A)");
                     }
                     break;
 
                 case "Θ":
                     //If the number of D batteries is greater than the number of AA batteries...
-                    if (bomb.GetBatteryCount(Battery.D) > bomb.GetBatteryCount(Battery.AA))
+                    if (bomb.GetBatteryCount(Battery.D) > (bomb.GetBatteryCount(Battery.AA) + bomb.GetBatteryCount(Battery.AAx3) + bomb.GetBatteryCount(Battery.AAx4)))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE THETA CONDITION: #1 (D batteries outnumber AA)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE THETA CONDITION: #1 (D batteries outnumber AA)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE THETA CONDITION: #1 (D batteries outnumber AA)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A4";
+                        DebugLog("UPPERCASE THETA CONDITION: #1 (D batteries outnumber AA)");
                     }
                     //Otherwise, if there is an unlit CAR indicator...
                     else if (bomb.IsIndicatorOff("CAR"))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                switch (int.Parse(serialNumberLastChar) % 4)
-                                {
-                                    case 0:
-                                        letter1CorrectZ = 0.0375f;
-                                        break;
-                                    case 1:
-                                        letter1CorrectZ = 0.0125f;
-                                        break;
-                                    case 2:
-                                        letter1CorrectZ = -0.0125f;
-                                        break;
-                                    case 3:
-                                        letter1CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("UPPERCASE THETA CONDITION: #2 (unlit CAR detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                switch (int.Parse(serialNumberLastChar) % 4)
-                                {
-                                    case 0:
-                                        letter2CorrectZ = 0.0375f;
-                                        break;
-                                    case 1:
-                                        letter2CorrectZ = 0.0125f;
-                                        break;
-                                    case 2:
-                                        letter2CorrectZ = -0.0125f;
-                                        break;
-                                    case 3:
-                                        letter2CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("UPPERCASE THETA CONDITION: #2 (unlit CAR detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                switch (int.Parse(serialNumberLastChar) % 4)
-                                {
-                                    case 0:
-                                        letter3CorrectZ = 0.0375f;
-                                        break;
-                                    case 1:
-                                        letter3CorrectZ = 0.0125f;
-                                        break;
-                                    case 2:
-                                        letter3CorrectZ = -0.0125f;
-                                        break;
-                                    case 3:
-                                        letter3CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("UPPERCASE THETA CONDITION: #2 (unlit CAR detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        //zIndex should be the position in possibleXorZ that matches our desired value
+                        //Serial 0: index 3 - shown 1, Serial 3: index 0 - shown 4, Serial 9: index 2 - shown 2
+                        int zIndex = 3 - (int.Parse(serialNumberLastChar) % 4);
+                        lettersCorrect[i] = CoordinateConversion(possibleXorZ[1], possibleXorZ[zIndex]);
+                        DebugLog("UPPERCASE THETA CONDITION: #2 (unlit CAR detected)");
                     }
                     //Otherwise, if the colors of all 3 letters are unique...
-                    else if (letters[i].GetComponent<TextMesh>().color != letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color && letters[i].GetComponent<TextMesh>().color != letters[(i + 2) % letters.Length].GetComponent<TextMesh>().color && letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color != letters[(i + 2) % letters.Length].GetComponent<TextMesh>().color)
+                    else if (lettersText[i].color != lettersText[(i + 1) % letters.Length].color && lettersText[i].color != lettersText[(i + 2) % letters.Length].color && lettersText[(i + 1) % letters.Length].color != lettersText[(i + 2) % letters.Length].color)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                switch (bomb.GetPortPlateCount() % 4)
-                                {
-                                    case 0:
-                                        letter1CorrectZ = 0.0375f;
-                                        break;
-                                    case 1:
-                                        letter1CorrectZ = 0.0125f;
-                                        break;
-                                    case 2:
-                                        letter1CorrectZ = -0.0125f;
-                                        break;
-                                    case 3:
-                                        letter1CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("UPPERCASE THETA CONDITION: #3 (all colors are unique)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                switch (bomb.GetPortPlateCount() % 4)
-                                {
-                                    case 0:
-                                        letter2CorrectZ = 0.0375f;
-                                        break;
-                                    case 1:
-                                        letter2CorrectZ = 0.0125f;
-                                        break;
-                                    case 2:
-                                        letter2CorrectZ = -0.0125f;
-                                        break;
-                                    case 3:
-                                        letter2CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("UPPERCASE THETA CONDITION: #3 (all colors are unique)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                switch (bomb.GetPortPlateCount() % 4)
-                                {
-                                    case 0:
-                                        letter3CorrectZ = 0.0375f;
-                                        break;
-                                    case 1:
-                                        letter3CorrectZ = 0.0125f;
-                                        break;
-                                    case 2:
-                                        letter3CorrectZ = -0.0125f;
-                                        break;
-                                    case 3:
-                                        letter3CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("UPPERCASE THETA CONDITION: #3 (all colors are unique)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        int zIndex = 3 - (bomb.GetPortPlateCount() % 4);
+                        lettersCorrect[i] = CoordinateConversion(possibleXorZ[3], possibleXorZ[zIndex]);
+                        DebugLog("UPPERCASE THETA CONDITION: #3 (all colors are unique)");
                     }
                     //Otherwise, if there is also a lowercase theta on the module...
-                    else if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text == "θ" || letters[(i + 2) % letters.Length].GetComponent<TextMesh>().text == "θ")
+                    else if (lettersText[(i + 1) % letters.Length].text == "θ" || lettersText[(i + 2) % letters.Length].text == "θ")
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE THETA CONDITION: #4 (lowercase theta detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE THETA CONDITION: #4 (lowercase theta detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE THETA CONDITION: #4 (lowercase theta detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D1";
+                        DebugLog("UPPERCASE THETA CONDITION: #4 (lowercase theta detected)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE THETA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE THETA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE THETA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B2";
+                        DebugLog("UPPERCASE THETA CONDITION: #5 (N/A)");
                     }
                     break;
 
                 case "θ":
                     //If this letter starts in a row unique to the other 2 letters...
-                    if ((i == 0 && letter1InitialZ != letter2InitialZ && letter1InitialZ != letter3InitialZ) || (i == 1 && letter2InitialZ != letter1InitialZ && letter2InitialZ != letter3InitialZ) || (i == 2 && letter3InitialZ != letter1InitialZ && letter3InitialZ != letter2InitialZ))
+                    if (lettersInitialZ[(i + 1) % letters.Length] != lettersInitialZ[i] && lettersInitialZ[(i + 2) % letters.Length] != lettersInitialZ[i])
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE THETA CONDITION: #1 (initial row is unique)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE THETA CONDITION: #1 (initial row is unique)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE THETA CONDITION: #1 (initial row is unique)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D3";
+                        DebugLog("LOWERCASE THETA CONDITION: #1 (initial row is unique)");
                     }
                     //Otherwise, if this letter is white...
-                    else if (letters[i].GetComponent<TextMesh>().color == new Color(1, 1, 1, 1))
+                    else if (lettersText[i].color == new Color(1, 1, 1, 1))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                switch (bomb.GetStrikes() % 4)
-                                {
-                                    case 0:
-                                        letter1CorrectZ = 0.0375f;
-                                        break;
-                                    case 1:
-                                        letter1CorrectZ = 0.0125f;
-                                        break;
-                                    case 2:
-                                        letter1CorrectZ = -0.0125f;
-                                        break;
-                                    case 3:
-                                        letter1CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("LOWERCASE THETA CONDITION: #2 (this letter is white)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                switch (bomb.GetStrikes() % 4)
-                                {
-                                    case 0:
-                                        letter2CorrectZ = 0.0375f;
-                                        break;
-                                    case 1:
-                                        letter2CorrectZ = 0.0125f;
-                                        break;
-                                    case 2:
-                                        letter2CorrectZ = -0.0125f;
-                                        break;
-                                    case 3:
-                                        letter2CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("LOWERCASE THETA CONDITION: #2 (this letter is white)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                switch (bomb.GetStrikes() % 4)
-                                {
-                                    case 0:
-                                        letter3CorrectZ = 0.0375f;
-                                        break;
-                                    case 1:
-                                        letter3CorrectZ = 0.0125f;
-                                        break;
-                                    case 2:
-                                        letter3CorrectZ = -0.0125f;
-                                        break;
-                                    case 3:
-                                        letter3CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("LOWERCASE THETA CONDITION: #2 (this letter is white)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        int zIndex = 3 - (bomb.GetStrikes() % 4);
+                        lettersCorrect[i] = CoordinateConversion(possibleXorZ[2], possibleXorZ[zIndex]);
+                        DebugLog("LOWERCASE THETA CONDITION: #2 (this letter is white)");
                     }
                     //Otherwise, if the number of solved modules is less than or equal to the number of current strikes...
                     else if (bomb.GetSolvedModuleNames().Count <= bomb.GetStrikes())
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = letter1InitialX;
-                                letter1CorrectZ = letter1InitialZ;
-                                Debug.Log("LOWERCASE THETA CONDITION: #3 (solved modules <= strikes)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = letter2InitialX;
-                                letter2CorrectZ = letter2InitialZ;
-                                Debug.Log("LOWERCASE THETA CONDITION: #3 (solved modules <= strikes)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = letter3InitialX;
-                                letter3CorrectZ = letter3InitialZ;
-                                Debug.Log("LOWERCASE THETA CONDITION: #3 (solved modules <= strikes)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = CoordinateConversion(lettersInitialX[i], lettersInitialZ[i]);
+                        DebugLog("LOWERCASE THETA CONDITION: #3 (solved modules <= strikes)");
                     }
                     //Otherwise, if there is a PS/2 port or any duplicate ports of any type...
                     else if (bomb.IsPortPresent(Port.PS2) || bomb.IsDuplicatePortPresent())
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE THETA CONDITION: #4 (PS/2 detected OR duplicate port detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE THETA CONDITION: #4 (PS/2 detected OR duplicate port detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE THETA CONDITION: #4 (PS/2 detected OR duplicate port detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B1";
+                        DebugLog("LOWERCASE THETA CONDITION: #4 (PS/2 detected OR duplicate port detected)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                if ((Mathf.Floor(bomb.GetTime()) / 60) % 2 == 1) //Only correct if minute is odd
-                                {
-                                    letter1CorrectX = -0.375f;
-                                    letter1CorrectZ = 0.0375f;
-                                }
-                                Debug.Log("LOWERCASE THETA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                if ((Mathf.Floor(bomb.GetTime()) / 60) % 2 == 1) //Only correct if minute is odd
-                                {
-                                    letter2CorrectX = -0.375f;
-                                    letter2CorrectZ = 0.0375f;
-                                }
-                                Debug.Log("LOWERCASE THETA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                if ((Mathf.Floor(bomb.GetTime()) / 60) % 2 == 1) //Only correct if minute is odd
-                                {
-                                    letter3CorrectX = -0.375f;
-                                    letter3CorrectZ = 0.0375f;
-                                }
-                                Debug.Log("LOWERCASE THETA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A2";
+                        DebugLog("LOWERCASE THETA CONDITION: #5 (N/A)");
                     }
                     break;
 
@@ -1614,129 +526,32 @@ public class greekLetterGridsScript : MonoBehaviour
                     //If the serial number contains an A...
                     if (bomb.GetSerialNumberLetters().Any(x => x == 'A'))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #1 (letter A detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #1 (letter A detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #1 (letter A detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A1";
+                        DebugLog("UPPERCASE LAMBDA CONDITION: #1 (letter A detected)");
                     }
                     //Otherwise, if the serial number contains a B...
                     else if (bomb.GetSerialNumberLetters().Any(x => x == 'B'))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #2 (letter B detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #2 (letter B detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #2 (letter B detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B1";
+                        DebugLog("UPPERCASE LAMBDA CONDITION: #2 (letter B detected)");
                     }
                     //Otherwise, if the serial number contains a D...
                     else if (bomb.GetSerialNumberLetters().Any(x => x == 'D'))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #3 (letter D detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #3 (letter D detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #3 (letter D detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D1";
+                        DebugLog("UPPERCASE LAMBDA CONDITION: #3 (letter D detected)");
                     }
                     //Otherwise if the serial number contains either an L or an M...
                     else if (bomb.GetSerialNumberLetters().Any(x => x == 'L' || x == 'M'))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #4 (letter L/M detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #4 (letter L/M detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = 0.0375f;
-
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #4 (letter L/M detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C1";
+                        DebugLog("UPPERCASE LAMBDA CONDITION: #4 (letter L/M detected)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = -0.0375f;
-
-                                Debug.Log("UPPERCASE LAMBDA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C4";
+                        DebugLog("UPPERCASE LAMBDA CONDITION: #5 (N/A)");
                     }
                     break;
 
@@ -1744,152 +559,39 @@ public class greekLetterGridsScript : MonoBehaviour
                     //If there are 2 or more lit indicators...
                     if (bomb.GetOnIndicators().Count() >= 2)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #1 (lit indicator count >= 2)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #1 (lit indicator count >= 2)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #1 (lit indicator count >= 2)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D3";
+                        DebugLog("LOWERCASE LAMBDA CONDITION: #1 (lit indicator count >= 2)");
                     }
                     //Otherwise, if this letter shares a color with only 1 other letter on the module...
-                    else if (letters[i].GetComponent<TextMesh>().color == letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color || letters[i].GetComponent<TextMesh>().color == letters[(i + 2) % letters.Length].GetComponent<TextMesh>().color)
+                    else if (lettersText[(i + 1) % letters.Length].color != lettersText[(i + 2) % letters.Length].color && (lettersText[i].color == lettersText[(i + 1) % letters.Length].color || lettersText[i].color == lettersText[(i + 2) % letters.Length].color))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #2 (shared color with only 1 letter)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #2 (shared color with only 1 letter)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #2 (shared color with only 1 letter)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B2";
+                        DebugLog("LOWERCASE LAMBDA CONDITION: #2 (shared color with only 1 letter)");
                     }
                     //Otherwise, if there are more batteries than port plates...
                     else if (bomb.GetBatteryCount() > bomb.GetPortPlateCount())
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #3 (battery count > port plate count)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #3 (battery count > port plate count)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #3 (battery count > port plate count)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A1";
+                        DebugLog("LOWERCASE LAMBDA CONDITION: #3 (battery count > port plate count)");
                     }
                     //Otherwise, if one letter on the module is yellow (not this letter)...
-                    else if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color == new Color(1, 1, 0, 1) || letters[(i + 2) % letters.Length].GetComponent<TextMesh>().color == new Color(1, 1, 0, 1))
+                    else if (lettersText[i].color != new Color(1, 1, 0, 1) && (lettersText[(i + 1) % letters.Length].color == new Color(1, 1, 0, 1) ^ lettersText[(i + 2) % letters.Length].color == new Color(1, 1, 0, 1)))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color == new Color(1, 1, 0, 1))
-                                {
-                                    letter1CorrectX = letter2CorrectX;
-                                    letter1CorrectZ = letter2CorrectZ;
-                                }
-                                else
-                                {
-                                    letter1CorrectX = letter3CorrectX;
-                                    letter1CorrectZ = letter3CorrectZ;
-                                }
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #4 (one letter is yellow)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color == new Color(1, 1, 0, 1))
-                                {
-                                    letter2CorrectX = letter3CorrectX;
-                                    letter2CorrectZ = letter3CorrectZ;
-                                }
-                                else
-                                {
-                                    letter2CorrectX = letter1CorrectX;
-                                    letter2CorrectZ = letter1CorrectZ;
-                                }
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #4 (one letter is yellow)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color == new Color(1, 1, 0, 1))
-                                {
-                                    letter3CorrectX = letter1CorrectX;
-                                    letter3CorrectZ = letter1CorrectZ;
-                                }
-                                else
-                                {
-                                    letter3CorrectX = letter2CorrectX;
-                                    letter3CorrectZ = letter2CorrectZ;
-                                }
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #4 (one letter is yellow)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        int yellowPosition;
+                        if (lettersText[(i + 1) % letters.Length].color == new Color(1, 1, 0, 1))
+                            yellowPosition = (i + 1) % letters.Length;
+                        else
+                            yellowPosition = (i + 2) % letters.Length;
+                        lettersCorrect[i] = "Yellow" + yellowPosition;
+                        DebugLog("LOWERCASE LAMBDA CONDITION: #4 (one letter is yellow)");
+                        DebugLog("The correct coordinate is based on the correct coordinate of the yellow letter.");
+                        continue;
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = 0.0375f;
-
-                                Debug.Log("LOWERCASE LAMBDA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D1";
+                        DebugLog("LOWERCASE LAMBDA CONDITION: #5 (N/A)");
                     }
                     break;
 
@@ -1897,177 +599,33 @@ public class greekLetterGridsScript : MonoBehaviour
                     //If it's Pi Day...
                     if (System.DateTime.Now.Month == 3 && System.DateTime.Now.Day == 14)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = letter1InitialX;
-                                letter1CorrectZ = letter1InitialZ;
-                                Debug.Log("UPPERCASE PI CONDITION: #1 (Happy Pi Day!)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = letter2InitialX;
-                                letter2CorrectZ = letter2InitialZ;
-                                Debug.Log("UPPERCASE PI CONDITION: #1 (Happy Pi Day!)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = letter3InitialX;
-                                letter3CorrectZ = letter3InitialZ;
-                                Debug.Log("UPPERCASE PI CONDITION: #1 (Happy Pi Day!)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = CoordinateConversion(lettersInitialX[i], lettersInitialZ[i]);
+                        DebugLog("UPPERCASE PI CONDITION: #1 (Happy Pi Day!)");
                     }
                     //Otherwise, if there is either a P or an I in the serial number...
                     else if (bomb.GetSerialNumberLetters().Any(x => x == 'P' || x == 'I'))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE PI CONDITION: #2 (serial number P or I detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE PI CONDITION: #2 (serial number P or I detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE PI CONDITION: #2 (serial number P or I detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B4";
+                        DebugLog("UPPERCASE PI CONDITION: #2 (serial number P or I detected)");
                     }
                     //Otherwise, if this letter starts in the same row as another letter...
-                    else if ((i == 0 && letter1InitialZ == letter2InitialZ || letter1InitialZ == letter3InitialZ) || (i == 1 && letter2InitialZ == letter1InitialZ || letter2InitialZ == letter3InitialZ) || (i == 2 && letter3InitialZ == letter2InitialZ || letter3InitialZ == letter1InitialZ))
+                    else if (lettersInitialZ[i] == lettersInitialZ[(i + 1) % letters.Length] || lettersInitialZ[i] == lettersInitialZ[(i + 2) % letters.Length])
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE PI CONDITION: #3 (initial row is shared)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE PI CONDITION: #3 (initial row is shared)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE PI CONDITION: #3 (initial row is shared)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B2";
+                        DebugLog("UPPERCASE PI CONDITION: #3 (initial row is shared)");
                     }
                     //Otherwise, if this letter starts in one of the corners of the grid...
-                    else if ((i == 0 && Math.Abs(letter1InitialX) == 0.0375f && Math.Abs(letter1InitialZ) == 0.0375f) || (i == 1 && Math.Abs(letter2InitialX) == 0.0375f && Math.Abs(letter2InitialZ) == 0.0375f) || (i == 2 && Math.Abs(letter3InitialX) == 0.0375f && Math.Abs(letter3InitialZ) == 0.0375f))
+                    else if (Math.Abs(lettersInitialX[i]) == 0.0375f && Math.Abs(lettersInitialZ[i]) == 0.0375f)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE PI CONDITION: #4 (initially in corner)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE PI CONDITION: #4 (initially in corner)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE PI CONDITION: #4 (initially in corner)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A3";
+                        DebugLog("UPPERCASE PI CONDITION: #4 (initially in corner)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                {
-                                    letter1CorrectX = -0.375f;
-                                    switch (((int)bomb.GetTime() / 60) % 4)
-                                    {
-                                        case 0:
-                                            letter1CorrectZ = 0.0375f;
-                                            break;
-                                        case 1:
-                                            letter1CorrectZ = 0.0125f;
-                                            break;
-                                        case 2:
-                                            letter1CorrectZ = -0.0125f;
-                                            break;
-                                        case 3:
-                                            letter1CorrectZ = -0.0375f;
-                                            break;
-                                    }
-                                }
-                                Debug.Log("UPPERCASE PI CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                if ((Mathf.Floor(bomb.GetTime()) / 60) % 2 == 1) //Only correct if minute is odd
-                                {
-                                    letter2CorrectX = -0.375f;
-                                    switch (((int)bomb.GetTime() / 60) % 4)
-                                    {
-                                        case 0:
-                                            letter2CorrectZ = 0.0375f;
-                                            break;
-                                        case 1:
-                                            letter2CorrectZ = 0.0125f;
-                                            break;
-                                        case 2:
-                                            letter2CorrectZ = -0.0125f;
-                                            break;
-                                        case 3:
-                                            letter2CorrectZ = -0.0375f;
-                                            break;
-                                    }
-                                }
-                                Debug.Log("UPPERCASE PI CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                if ((Mathf.Floor(bomb.GetTime()) / 60) % 2 == 1) //Only correct if minute is odd
-                                {
-                                    letter3CorrectX = -0.375f;
-                                    switch (((int)bomb.GetTime() / 60) % 4)
-                                    {
-                                        case 0:
-                                            letter3CorrectZ = 0.0375f;
-                                            break;
-                                        case 1:
-                                            letter3CorrectZ = 0.0125f;
-                                            break;
-                                        case 2:
-                                            letter3CorrectZ = -0.0125f;
-                                            break;
-                                        case 3:
-                                            letter3CorrectZ = -0.0375f;
-                                            break;
-                                    }
-                                }
-                                Debug.Log("UPPERCASE PI CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        int zIndex = 3 - (((int)bomb.GetTime() / 60) % 4);
+                        lettersCorrect[i] = CoordinateConversion(possibleXorZ[0], possibleXorZ[zIndex]);
+                        DebugLog("UPPERCASE PI CONDITION: #5 (N/A)");
                     }
                     break;
 
@@ -2075,823 +633,227 @@ public class greekLetterGridsScript : MonoBehaviour
                     //If the last digit of the serial number is either 3, 1, or 4...
                     if (int.Parse(serialNumberLastChar) == 3 || int.Parse(serialNumberLastChar) == 1 || int.Parse(serialNumberLastChar) == 4)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = letter1InitialX;
-                                letter1CorrectZ = letter1InitialZ;
-                                Debug.Log("LOWERCASE PI CONDITION: #1 (serial number is 3, 1, or 4)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = letter2InitialX;
-                                letter2CorrectZ = letter2InitialZ;
-                                Debug.Log("LOWERCASE PI CONDITION: #1 (serial number is 3, 1, or 4)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = letter3InitialX;
-                                letter3CorrectZ = letter3InitialZ;
-                                Debug.Log("LOWERCASE PI CONDITION: #1 (serial number is 3, 1, or 4)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = CoordinateConversion(lettersInitialX[i], lettersInitialZ[i]);
+                        DebugLog("LOWERCASE PI CONDITION: #1 (serial number is 3, 1, or 4)");
                     }
                     //Otherwise, if the number of battery holders is either 3, 1, or 4...
                     else if (bomb.GetBatteryHolderCount() == 3 || bomb.GetBatteryHolderCount() == 1 || bomb.GetBatteryHolderCount() == 4)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                switch (bomb.GetBatteryHolderCount())
-                                {
-                                    case 1:
-                                        letter1CorrectZ = 0.0375f;
-                                        break;
-                                    case 3:
-                                        letter1CorrectZ = -0.0125f;
-                                        break;
-                                    case 4:
-                                        letter1CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("LOWERCASE PI CONDITION: #2 (battery holder count is 3, 1, or 4)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                switch (bomb.GetBatteryHolderCount())
-                                {
-                                    case 1:
-                                        letter2CorrectZ = 0.0375f;
-                                        break;
-                                    case 3:
-                                        letter2CorrectZ = -0.0125f;
-                                        break;
-                                    case 4:
-                                        letter2CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("LOWERCASE PI CONDITION: #2 (battery holder count is 3, 1, or 4)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                switch (bomb.GetBatteryHolderCount())
-                                {
-                                    case 1:
-                                        letter3CorrectZ = 0.0375f;
-                                        break;
-                                    case 3:
-                                        letter3CorrectZ = -0.0125f;
-                                        break;
-                                    case 4:
-                                        letter3CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("LOWERCASE PI CONDITION: #2 (battery holder count is 3, 1, or 4)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        //4 holders -> 3 index -> 0 pos, 1 holder -> 0 index -> 3 pos, 3 holders -> 2 index -> 1 pos
+                        int zIndex = 4 - (bomb.GetBatteryHolderCount() % 4);
+                        lettersCorrect[i] = CoordinateConversion(possibleXorZ[3], possibleXorZ[zIndex]);
+                        DebugLog("LOWERCASE PI CONDITION: #2 (battery holder count is 3, 1, or 4)");
                     }
                     //Otherwise, if the number of indicators (both lit and unlit) is either 3, 1, or 4...
                     else if (bomb.GetIndicators().Count() == 3 || bomb.GetIndicators().Count() == 1 || bomb.GetIndicators().Count() == 4)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                switch (bomb.GetBatteryHolderCount())
-                                {
-                                    case 1:
-                                        letter1CorrectZ = 0.0375f;
-                                        break;
-                                    case 3:
-                                        letter1CorrectZ = -0.0125f;
-                                        break;
-                                    case 4:
-                                        letter1CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("LOWERCASE PI CONDITION: #3 (indicator count is 3, 1, or 4)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                switch (bomb.GetBatteryHolderCount())
-                                {
-                                    case 1:
-                                        letter2CorrectZ = 0.0375f;
-                                        break;
-                                    case 3:
-                                        letter2CorrectZ = -0.0125f;
-                                        break;
-                                    case 4:
-                                        letter2CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("LOWERCASE PI CONDITION: #3 (indicator count is 3, 1, or 4)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                switch (bomb.GetBatteryHolderCount())
-                                {
-                                    case 1:
-                                        letter3CorrectZ = 0.0375f;
-                                        break;
-                                    case 3:
-                                        letter3CorrectZ = -0.0125f;
-                                        break;
-                                    case 4:
-                                        letter3CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("LOWERCASE PI CONDITION: #3 (indicator count is 3, 1, or 4)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        int zIndex = 4 - (bomb.GetIndicators().Count() % 4);
+                        lettersCorrect[i] = CoordinateConversion(possibleXorZ[1], possibleXorZ[zIndex]);
+                        DebugLog("LOWERCASE PI CONDITION: #3 (indicator count is 3, 1, or 4)");
                     }
                     //Otherwise, if the number of solved modules is either 3, 1, or 4...
                     else if (bomb.GetSolvedModuleNames().Count() == 3 || bomb.GetSolvedModuleNames().Count() == 1 || bomb.GetSolvedModuleNames().Count() == 4)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                switch (bomb.GetBatteryHolderCount())
-                                {
-                                    case 1:
-                                        letter1CorrectZ = 0.0375f;
-                                        break;
-                                    case 3:
-                                        letter1CorrectZ = -0.0125f;
-                                        break;
-                                    case 4:
-                                        letter1CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("LOWERCASE PI CONDITION: #4 (solved module count is 3, 1, or 4)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                switch (bomb.GetBatteryHolderCount())
-                                {
-                                    case 1:
-                                        letter2CorrectZ = 0.0375f;
-                                        break;
-                                    case 3:
-                                        letter2CorrectZ = -0.0125f;
-                                        break;
-                                    case 4:
-                                        letter2CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("LOWERCASE PI CONDITION: #4 (solved module count is 3, 1, or 4)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                switch (bomb.GetBatteryHolderCount())
-                                {
-                                    case 1:
-                                        letter3CorrectZ = 0.0375f;
-                                        break;
-                                    case 3:
-                                        letter3CorrectZ = -0.0125f;
-                                        break;
-                                    case 4:
-                                        letter3CorrectZ = -0.0375f;
-                                        break;
-                                }
-                                Debug.Log("LOWERCASE PI CONDITION: #4 (solved module count is 3, 1, or 4)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        int zIndex = 4 - (bomb.GetSolvableModuleNames().Count() % 4);
+                        lettersCorrect[i] = CoordinateConversion(possibleXorZ[2], possibleXorZ[zIndex]);
+                        DebugLog("LOWERCASE PI CONDITION: #4 (solved module count is 3, 1, or 4)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE PI CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE PI CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE PI CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C3";
+                        DebugLog("LOWERCASE PI CONDITION: #5 (N/A)");
                     }
                     break;
 
                 case "Σ":
-                    if (!bomb.IsIndicatorOn("SIG"))
+                case "σ":
+                    if (bomb.IsIndicatorOn("SIG"))
+                    {
+                        lettersCorrect[i] = CoordinateConversion(lettersInitialX[i], lettersInitialZ[i]);
+                        DebugLog("SIGMA CONDITION: #EX (SIG is present and on)");
+                    }
+                    else if (lettersText[i].text == "Σ")
                     {
                         //If the number of batteries plus the number of current strikes is greater than or equal to 5...
                         if (bomb.GetBatteryCount() + bomb.GetStrikes() >= 5)
                         {
-                            switch (i)
-                            {
-                                case 0:
-                                    letter1CorrectX = -0.0375f;
-                                    letter1CorrectZ = -0.0375f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #1 (battery count + strike count >= 5)");
-                                    Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                    break;
-                                case 1:
-                                    letter2CorrectX = -0.0375f;
-                                    letter2CorrectZ = -0.0375f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #1 (battery count + strike count >= 5)");
-                                    Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                    break;
-                                case 2:
-                                    letter3CorrectX = -0.0375f;
-                                    letter3CorrectZ = -0.0375f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #1 (battery count + strike count >= 5)");
-                                    Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                    break;
-                            }
+                            lettersCorrect[i] = "A4";
+                            DebugLog("UPPERCASE SIGMA CONDITION: #1 (battery count + strike count >= 5)");
                         }
                         //Otherwise, if the number of lit indicators plus the number of port plates is greater than or equal to 5...
                         else if (bomb.GetOnIndicators().Count() + bomb.GetPortPlateCount() >= 5)
                         {
-                            switch (i)
-                            {
-                                case 0:
-                                    letter1CorrectX = 0.0125f;
-                                    letter1CorrectZ = -0.0125f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #2 (lit indicator count + port plate count >= 5)");
-                                    Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                    break;
-                                case 1:
-                                    letter2CorrectX = 0.0125f;
-                                    letter2CorrectZ = -0.0125f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #2 (lit indicator count + port plate count >= 5)");
-                                    Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                    break;
-                                case 2:
-                                    letter3CorrectX = 0.0125f;
-                                    letter3CorrectZ = -0.0125f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #2 (lit indicator count + port plate count >= 5)");
-                                    Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                    break;
-                            }
+                            lettersCorrect[i] = "C2";
+                            DebugLog("UPPERCASE SIGMA CONDITION: #2 (lit indicator count + port plate count >= 5)");
                         }
                         //Otherwise, if the number of unlit indicators plus the last digit of the serial number is greater than or equal to 5...
                         else if (bomb.GetOffIndicators().Count() + int.Parse(serialNumberLastChar) >= 5)
                         {
-                            switch (i)
-                            {
-                                case 0:
-                                    letter1CorrectX = -0.0125f;
-                                    letter1CorrectZ = 0.0375f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #3 (unlit indicator count + last digit of serial number >= 5)");
-                                    Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                    break;
-                                case 1:
-                                    letter2CorrectX = -0.0125f;
-                                    letter2CorrectZ = 0.0375f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #3 (unlit indicator count + last digit of serial number >= 5)");
-                                    Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                    break;
-                                case 2:
-                                    letter3CorrectX = -0.0125f;
-                                    letter3CorrectZ = 0.0375f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #3 (unlit indicator count + last digit of serial number >= 5)");
-                                    Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                    break;
-                            }
+                            lettersCorrect[i] = "B1";
+                            DebugLog("UPPERCASE SIGMA CONDITION: #3 (unlit indicator count + last digit of serial number >= 5)");
                         }
                         //Otherwise, if the number of solved modules plus the number of battery holders is greater than or equal to 5...
                         else if (bomb.GetSolvedModuleNames().Count() + bomb.GetBatteryHolderCount() >= 5)
                         {
-                            switch (i)
-                            {
-                                case 0:
-                                    letter1CorrectX = 0.0375f;
-                                    letter1CorrectZ = 0.0375f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #4 (solved module count + battery holder count >= 5)");
-                                    Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                    break;
-                                case 1:
-                                    letter2CorrectX = 0.0375f;
-                                    letter2CorrectZ = 0.0375f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #4 (solved module count + battery holder count >= 5)");
-                                    Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                    break;
-                                case 2:
-                                    letter3CorrectX = 0.0375f;
-                                    letter3CorrectZ = 0.0375f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #4 (solved module count + battery holder count >= 5)");
-                                    Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                    break;
-                            }
+                            lettersCorrect[i] = "D1";
+                            DebugLog("UPPERCASE SIGMA CONDITION: #4 (solved module count + battery holder count >= 5)");
                         }
                         //Otherwise, if nothing applies...
                         else
                         {
-                            switch (i)
-                            {
-                                case 0:
-                                    letter1CorrectX = -0.0125f;
-                                    letter1CorrectZ = -0.0125f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #5 (N/A)");
-                                    Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                    break;
-                                case 1:
-                                    letter2CorrectX = -0.0125f;
-                                    letter2CorrectZ = -0.0125f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #5 (N/A)");
-                                    Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                    break;
-                                case 2:
-                                    letter3CorrectX = -0.0125f;
-                                    letter3CorrectZ = -0.0125f;
-                                    Debug.Log("UPPERCASE SIGMA CONDITION: #5 (N/A)");
-                                    Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                    break;
-                            }
+                            lettersCorrect[i] = "B3";
+                            DebugLog("UPPERCASE SIGMA CONDITION: #5 (N/A)");
                         }
-                        break;
                     }
+                    
+                    //Lowercase Sigma
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = letter1InitialX;
-                                letter1CorrectZ = letter1InitialZ;
-                                Debug.Log("UPPERCASE SIGMA CONDITION: #EX (SIG is present and on)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = letter2InitialX;
-                                letter2CorrectZ = letter2InitialZ;
-                                Debug.Log("UPPERCASE SIGMA CONDITION: #EX (SIG is present and on)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = letter3InitialX;
-                                letter3CorrectZ = letter3InitialZ;
-                                Debug.Log("UPPERCASE SIGMA CONDITION: #EX (SIG is present and on)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
-                        break;
-                    }
-
-                case "σ":
-                    if (!bomb.IsIndicatorOn("SIG"))
-                    {
                         //If this letter is green...
-                        if (letters[i].GetComponent<TextMesh>().color == new Color(0, 1, 0, 1))
+                        if (lettersText[i].color == new Color(0, 1, 0, 1))
                         {
-                            switch (i)
-                            {
-                                case 0:
-                                    letter1CorrectX = -0.0125f;
-                                    letter1CorrectZ = 0.0375f;
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #1 (this letter is green)");
-                                    Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                    break;
-                                case 1:
-                                    letter2CorrectX = -0.0125f;
-                                    letter2CorrectZ = 0.0375f;
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #1 (this letter is green)");
-                                    Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                    break;
-                                case 2:
-                                    letter3CorrectX = -0.0125f;
-                                    letter3CorrectZ = 0.0375f;
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #1 (this letter is green)");
-                                    Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                    break;
-                            }
+                            lettersCorrect[i] = "B1";
+                            DebugLog("LOWERCASE SIGMA CONDITION: #1 (this letter is green)");
                         }
                         //Otherwise, if there is a parallel port...
                         else if (bomb.IsPortPresent(Port.Parallel))
                         {
-                            switch (i)
-                            {
-                                case 0:
-                                    letter1CorrectX = -0.0125f;
-                                    letter1CorrectZ = -0.0375f;
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #2 (parallel port detected)");
-                                    Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                    break;
-                                case 1:
-                                    letter2CorrectX = -0.0125f;
-                                    letter2CorrectZ = -0.0375f;
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #2 (parallel port detected)");
-                                    Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                    break;
-                                case 2:
-                                    letter3CorrectX = -0.0125f;
-                                    letter3CorrectZ = -0.0375f;
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #2 (parallel port detected)");
-                                    Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                    break;
-                            }
+                            lettersCorrect[i] = "B4";
+                            DebugLog("LOWERCASE SIGMA CONDITION: #2 (parallel port detected)");
                         }
                         //Otherwise, if one and only one of the other letters is an uppercase lambda on the module...
-                        else if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text == "Λ" ^ letters[(i + 2) % letters.Length].GetComponent<TextMesh>().text == "Λ")
+                        else if (lettersText[(i + 1) % letters.Length].text == "Λ" ^ lettersText[(i + 2) % letters.Length].text == "Λ")
                         {
-                            switch (i)
-                            {
-                                case 0:
-                                    if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text == "Λ")
-                                    {
-                                        letter1CorrectX = letter2InitialX;
-                                        letter1CorrectZ = letter2InitialZ;
-                                    }
-                                    else
-                                    {
-                                        letter1CorrectX = letter3InitialX;
-                                        letter1CorrectZ = letter3InitialZ;
-                                    }
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #3 (only 1 uppercase lambda detected)");
-                                    Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                    break;
-                                case 1:
-                                    if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text == "Λ")
-                                    {
-                                        letter2CorrectX = letter3InitialX;
-                                        letter2CorrectZ = letter3InitialZ;
-                                    }
-                                    else
-                                    {
-                                        letter2CorrectX = letter1InitialX;
-                                        letter2CorrectZ = letter1InitialZ;
-                                    }
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #3 (only 1 uppercase lambda detected)");
-                                    Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                    break;
-                                case 2:
-                                    if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text == "Λ")
-                                    {
-                                        letter3CorrectX = letter1InitialX;
-                                        letter3CorrectZ = letter1InitialZ;
-                                    }
-                                    else
-                                    {
-                                        letter3CorrectX = letter2InitialX;
-                                        letter3CorrectZ = letter2InitialZ;
-                                    }
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #3 (only 1 uppercase lambda detected)");
-                                    Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                    break;
-                            }
+                            int lambdaPosition;
+                            if (lettersText[(i + 1) % letters.Length].text == "Λ")
+                                lambdaPosition = (i + 1) % letters.Length;
+                            else
+                                lambdaPosition = (i + 2) % letters.Length;
+                            lettersCorrect[i] = CoordinateConversion(lettersInitialX[lambdaPosition], lettersInitialZ[lambdaPosition]);
+                            DebugLog("LOWERCASE SIGMA CONDITION: #3 (only 1 uppercase lambda detected)");
                         }
                         //Otherwise, if this letter starts in the fourth row...
-                        else if ((i == 0 && letter1InitialZ == -0.0375f) || (i == 1 && letter2InitialZ == -0.0375f) || (i == 2 && letter3InitialZ == -0.0375f))
+                        else if (lettersInitialZ[i] == -0.0375f)
                         {
-                            switch (i)
-                            {
-                                case 0:
-                                    letter1CorrectX = letter1InitialX;
-                                    letter1CorrectZ = letter1InitialZ;
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #4 (initial row is row 4)");
-                                    Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                    break;
-                                case 1:
-                                    letter2CorrectX = letter2InitialX;
-                                    letter2CorrectZ = letter2InitialZ;
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #4 (initial row is row 4)");
-                                    Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                    break;
-                                case 2:
-                                    letter3CorrectX = letter3InitialX;
-                                    letter3CorrectZ = letter3InitialZ;
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #4 (initial row is row 4)");
-                                    Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                    break;
-                            }
+                            lettersCorrect[i] = CoordinateConversion(lettersInitialX[i], lettersInitialZ[i]);
+                            DebugLog("LOWERCASE SIGMA CONDITION: #4 (initial row is row 4)");
                         }
                         //Otherwise, if nothing else applies...
                         else
                         {
-                            switch (i)
-                            {
-                                case 0:
-                                    letter1CorrectX = -0.0375f;
-                                    letter1CorrectZ = 0.0375f;
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #5 (N/A)");
-                                    Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                    break;
-                                case 1:
-                                    letter2CorrectX = -0.0375f;
-                                    letter2CorrectZ = 0.0375f;
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #5 (N/A)");
-                                    Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                    break;
-                                case 2:
-                                    letter3CorrectX = -0.0375f;
-                                    letter3CorrectZ = 0.0375f;
-                                    Debug.Log("LOWERCASE SIGMA CONDITION: #5 (N/A)");
-                                    Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                    break;
-                            }
+                            lettersCorrect[i] = "A1";
+                            DebugLog("LOWERCASE SIGMA CONDITION: #5 (N/A)");
                         }
-                        break;
                     }
-                    else
-                    {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = letter1InitialX;
-                                letter1CorrectZ = letter1InitialZ;
-                                Debug.Log("LOWERCASE SIGMA CONDITION: #EX (SIG is present and on)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = letter2InitialX;
-                                letter2CorrectZ = letter2InitialZ;
-                                Debug.Log("LOWERCASE SIGMA CONDITION: #EX (SIG is present and on)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = letter3InitialX;
-                                letter3CorrectZ = letter3InitialZ;
-                                Debug.Log("LOWERCASE SIGMA CONDITION: #EX (SIG is present and on)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
-                        break;
-                    }
+                    break;
 
                 case "Ω":
                     //If this letter is magenta...
-                    if (letters[i].GetComponent<TextMesh>().color == new Color(1, 0, 1, 1))
+                    if (lettersText[i].color == new Color(1, 0, 1, 1))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #1 (letter is magenta)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #1 (letter is magenta)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #1 (letter is magenta)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C4";
+                        DebugLog("UPPERCASE OMEGA CONDITION: #1 (letter is magenta)");
                     }
                     //Otherwise, if the serial number contains a Z...
                     else if (bomb.GetSerialNumberLetters().Contains('Z'))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #2 (serial number Z detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #2 (serial number Z detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #2 (serial number Z detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C2";
+                        DebugLog("UPPERCASE OMEGA CONDITION: #2 (serial number Z detected)");
                     }
                     //Otherwise, if there is an uppercase alpha on the module...
-                    else if (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().text == "A" || letters[(i + 2) % letters.Length].GetComponent<TextMesh>().text == "A")
+                    else if (lettersText[(i + 1) % letters.Length].text == "A" || lettersText[(i + 2) % letters.Length].text == "A")
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #3 (uppercase alpha detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #3 (uppercase alpha detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #3 (uppercase alpha detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A3";
+                        DebugLog("UPPERCASE OMEGA CONDITION: #3 (uppercase alpha detected)");
                     }
                     //Otherwise, if the last digit of the serial number is composite...
                     else if (!primeNumbers.Contains(serialNumberLastChar))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #4 (serial number last digit is composite)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #4 (serial number last digit is composite)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #4 (serial number last digit is composite)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B3";
+                        DebugLog("UPPERCASE OMEGA CONDITION: #4 (serial number last digit is composite)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = 0.0375f;
-                                Debug.Log("UPPERCASE OMEGA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D1";
+                        DebugLog("UPPERCASE OMEGA CONDITION: #5 (N/A)");
                     }
                     break;
 
                 case "ω":
                     //If this letter starts in C4...
-                    if ((i == 0 && letter1InitialX == 0.0125f && letter1InitialZ == -0.0375f) || (i == 1 && letter2InitialX == 0.0125f && letter2InitialZ == -0.0375f) || (i == 2 && letter3InitialX == 0.0125f && letter3InitialZ == -0.0375f))
+                    if (lettersInitialX[i] == 0.0125f && lettersInitialZ[i] == -0.0375f)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0125f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #1 (this letter starts in C4)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0125f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #1 (this letter starts in C4)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0125f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #1 (this letter starts in C4)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "B2";
+                        DebugLog("LOWERCASE OMEGA CONDITION: #1 (this letter starts in C4)");
                     }
                     //Otherwise, if the serial number contains a W...
                     else if (bomb.GetSerialNumberLetters().Contains('W'))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = -0.0375f;
-                                letter1CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #2 (serial letter contains W)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = -0.0375f;
-                                letter2CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #2 (serial letter contains W)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = -0.0375f;
-                                letter3CorrectZ = 0.0125f;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #2 (serial letter contains W)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "A2";
+                        DebugLog("LOWERCASE OMEGA CONDITION: #2 (serial letter contains W)");
                     }
                     //Otherwise, if there are 0 batteries...
                     else if (bomb.GetBatteryCount() == 0)
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0125f;
-                                letter1CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #3 (0 batteries detected)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0125f;
-                                letter2CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #3 (0 batteries detected)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0125f;
-                                letter3CorrectZ = -0.0125f;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #3 (0 batteries detected)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "C3";
+                        DebugLog("LOWERCASE OMEGA CONDITION: #3 (0 batteries detected)");
                     }
                     //Otherwise, if this letter is cyan AND only one of the other letters is white...
-                    else if (letters[i].GetComponent<TextMesh>().color == new Color(0, 1, 1, 1) && (letters[(i + 1) % letters.Length].GetComponent<TextMesh>().color == new Color(1, 1, 1, 1) ^ letters[(i + 2) % letters.Length].GetComponent<TextMesh>().color == new Color(1, 1, 1, 1)))
+                    else if (lettersText[i].color == new Color(0, 1, 1, 1) && (lettersText[(i + 1) % letters.Length].color == new Color(1, 1, 1, 1) ^ lettersText[(i + 2) % letters.Length].color == new Color(1, 1, 1, 1)))
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = 0.0375f;
-                                letter1CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #4 (this letter is cyan and only 1 of the other letters is white)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = 0.0375f;
-                                letter2CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #4 (this letter is cyan and only 1 of the other letters is white)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = 0.0375f;
-                                letter3CorrectZ = -0.0375f;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #4 (this letter is cyan and only 1 of the other letters is white)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = "D4";
+                        DebugLog("LOWERCASE OMEGA CONDITION: #4 (this letter is cyan and only 1 of the other letters is white)");
                     }
                     //Otherwise, if nothing applies...
                     else
                     {
-                        switch (i)
-                        {
-                            case 0:
-                                letter1CorrectX = letter1InitialX;
-                                letter1CorrectZ = letter1InitialZ;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter1CorrectX.ToString() + " and the correct Z is " + letter1CorrectZ.ToString());
-                                break;
-                            case 1:
-                                letter2CorrectX = letter2InitialX;
-                                letter2CorrectZ = letter2InitialZ;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter2CorrectX.ToString() + " and the correct Z is " + letter2CorrectZ.ToString());
-                                break;
-                            case 2:
-                                letter3CorrectX = letter3InitialX;
-                                letter3CorrectZ = letter3InitialZ;
-                                Debug.Log("LOWERCASE OMEGA CONDITION: #5 (N/A)");
-                                Debug.Log("The correct X is " + letter3CorrectX.ToString() + " and the correct Z is " + letter3CorrectZ.ToString());
-                                break;
-                        }
+                        lettersCorrect[i] = CoordinateConversion(lettersInitialX[i], lettersInitialZ[i]);
+                        DebugLog("LOWERCASE OMEGA CONDITION: #5 (N/A)");
                     }
                     break;
 
             }
+            DebugLog("The correct coordinate is {0}", lettersCorrect[i]);
         }
+        for (int i = 0; i < letters.Length; i++)
+        {
+            if (lettersCorrect[i].StartsWith("Yellow"))
+            {
+                int index = int.Parse(lettersCorrect[i].Replace("Yellow", ""));
+                lettersCorrect[i] = lettersCorrect[index];
+                DebugLog("The correct coordinate for λ condition #4 is " + lettersCorrect[i]);
+                break;
+            }
+        }
+        letter1CorrectX = possibleXorZ[lettersCorrect[0][0] - 'A'];
+        letter2CorrectX = possibleXorZ[lettersCorrect[1][0] - 'A'];
+        letter3CorrectX = possibleXorZ[lettersCorrect[2][0] - 'A'];
+        //1 -> 3, 2 -> 2, 3 -> 1, 4 -> 0
+        letter1CorrectZ = possibleXorZ[4 - (lettersCorrect[0][1] - '0')];
+        letter2CorrectZ = possibleXorZ[4 - (lettersCorrect[1][1] - '0')];
+        letter3CorrectZ = possibleXorZ[4 - (lettersCorrect[2][1] - '0')];
+        //Verify the expected coordinate is the same as the reported coordinate (Debug code)
+        Debug.LogFormat("<Greek Letter Grid #{0}> First:{1}, Second:{2}, Third:{3}", moduleId,
+            CoordinateConversion(letter1CorrectX, letter1CorrectZ),
+            CoordinateConversion(letter2CorrectX, letter2CorrectZ),
+            CoordinateConversion(letter3CorrectX, letter3CorrectZ));
+    }
+
+    string CoordinateConversion(float coordinateX, float coordinateZ)
+    {
+         Dictionary<float, char> conversion = new Dictionary<float, char>
+        {
+            { possibleXorZ[0], 'A' },
+            { possibleXorZ[1], 'B' },
+            { possibleXorZ[2], 'C' },
+            { possibleXorZ[3], 'D' }
+        };
+        char X = conversion[coordinateX];
+        //'A' - 'A' = 0, 4 - 0 = 4 // 'D' - 'A' = 3, 4 - 3 = 1
+        int Z = 4 - (conversion[coordinateZ] - 'A');
+        return X.ToString() + Z.ToString();
     }
 
     //Arrow and Resest Button Interaction Methods
@@ -2901,7 +863,7 @@ public class greekLetterGridsScript : MonoBehaviour
         upButton.AddInteractionPunch();
         if (selectedLetter != null && moduleSolved == false)
         {
-            Debug.Log("You pressed up! You deserve a cookie!");
+            DebugLog("You pressed up! You deserve a cookie!");
             if (selectedLetterZ != 0.0375f)
             {
                 selectedLetter.transform.localPosition = new Vector3(selectedLetterX, 0.013f, selectedLetterZ += 0.025f);
@@ -2915,7 +877,7 @@ public class greekLetterGridsScript : MonoBehaviour
         downButton.AddInteractionPunch();
         if (selectedLetter != null && moduleSolved == false)
         {
-            Debug.Log("You pressed down! You deserve a cookie!");
+            DebugLog("You pressed down! You deserve a cookie!");
             if (selectedLetterZ != -0.0375f)
             {
                 selectedLetter.transform.localPosition = new Vector3(selectedLetterX, 0.013f, selectedLetterZ -= 0.025f);
@@ -2929,7 +891,7 @@ public class greekLetterGridsScript : MonoBehaviour
         leftButton.AddInteractionPunch();
         if (selectedLetter != null && moduleSolved == false)
         {
-            Debug.Log("You pressed left! You deserve a cookie!");
+            DebugLog("You pressed left! You deserve a cookie!");
             if (selectedLetterX != -0.0375f)
             {
                 selectedLetter.transform.localPosition = new Vector3(selectedLetterX -= 0.025f, 0.013f, selectedLetterZ);
@@ -2943,7 +905,7 @@ public class greekLetterGridsScript : MonoBehaviour
         rightButton.AddInteractionPunch();
         if (selectedLetter != null && moduleSolved == false)
         {
-            Debug.Log("You pressed right! You deserve a cookie!");
+            DebugLog("You pressed right! You deserve a cookie!");
             if (selectedLetterX != 0.0375f)
             {
                 selectedLetter.transform.localPosition = new Vector3(selectedLetterX += 0.025f, 0.013f, selectedLetterZ);
@@ -2961,7 +923,7 @@ public class greekLetterGridsScript : MonoBehaviour
         }
         else
         {
-            Debug.Log("You reset the module.");
+            DebugLog("You reset the module.");
             letters[0].transform.localPosition = new Vector3(letter1InitialX, 0.013f, letter1InitialZ);
             letters[1].transform.localPosition = new Vector3(letter2InitialX, 0.013f, letter2InitialZ);
             letters[2].transform.localPosition = new Vector3(letter3InitialX, 0.013f, letter3InitialZ);
@@ -2984,24 +946,24 @@ public class greekLetterGridsScript : MonoBehaviour
             moduleSolved = true;
             GetComponent<KMBombModule>().HandlePass();
             audio.PlayGameSoundAtTransform(KMSoundOverride.SoundEffect.CorrectChime, transform);
-            Debug.Log("Module solved. Gj!");
+            DebugLog("Module solved. Gj!");
         }
         else
         {
             GetComponent<KMBombModule>().HandleStrike();
-            Debug.Log("You failed. Try again, but do better! The correct X for Letter 1 was " + letter1CorrectX.ToString() + " and the correct Z was " + letter1CorrectZ.ToString() + ". Your X was " + letter1CurrentX.ToString() + " and your Z was " + letter1CurrentZ.ToString());
-            Debug.Log("The correct X for Letter 2 was " + letter2CorrectX.ToString() + " and the correct Z was " + letter2CorrectZ.ToString() + ". Your X was " + letter2CurrentX.ToString() + " and your Z was " + letter2CurrentZ.ToString());
-            Debug.Log("The correct X for Letter 3 was " + letter3CorrectX.ToString() + " and the correct Z was " + letter3CorrectZ.ToString() + ". Your X was " + letter3CurrentX.ToString() + " and your Z was " + letter3CurrentZ.ToString());
+            DebugLog("You failed. Try again, but do better! The correct coordinate for Letter 1 was " + CoordinateConversion(letter1CorrectX, letter1CorrectZ) + ". Your submitted coordinate was " + CoordinateConversion(letter1CurrentX, letter1CurrentZ));
+            DebugLog("The correct coordinate for Letter 2 was " + CoordinateConversion(letter2CorrectX, letter2CorrectZ) + ". Your submitted coordinate was " + CoordinateConversion(letter2CurrentX, letter2CurrentZ));
+            DebugLog("The correct coordinate for Letter 3 was " + CoordinateConversion(letter3CorrectX, letter3CorrectZ) + ". Your submitted coordinate was " + CoordinateConversion(letter3CurrentX, letter3CurrentZ));
             Start(); //Reset module with new letters in new positions.
 
         }
     }
 
     //Letter Button Interaction Methods
-    void PressLetter(KMSelectable letter)
+    void PressLetter(KMSelectable letter, TextMesh text)
     {
         GetComponent<KMAudio>().PlayGameSoundAtTransform(KMSoundOverride.SoundEffect.ButtonPress, transform);
-        Debug.Log("You pressed " + letter.GetComponent<TextMesh>().text);
+        DebugLog("You pressed " + text);
         selectedLetter = letter;
         selectedLetterX = selectedLetter.transform.localPosition.x;
         selectedLetterZ = selectedLetter.transform.localPosition.z;
@@ -3017,6 +979,12 @@ public class greekLetterGridsScript : MonoBehaviour
         letter2CurrentZ = letters[1].transform.localPosition.z;
         letter3CurrentX = letters[2].transform.localPosition.x;
         letter3CurrentZ = letters[2].transform.localPosition.z;
+    }
+
+    void DebugLog(string log, params object[] args)
+    {
+        string logData = string.Format(log, args);
+        Debug.LogFormat("[Greek Letter Grid #{0}] {1}", moduleId, logData);
     }
 
     //TP Support


### PR DESCRIPTION
- Some conditions were applied to the wrong coordinates. To better troubleshoot this, most coordinates will now be a simple letter-number string that gets converted back to floats at the end of the for statement.
- Logging should now appear in the Logfile Analyzer
- Conditions that were based on strikes, solves, and time were all calculated before the bomb activated. This doesn't make sense, so all calculations are now made after submitting. Unfortunately, this means conditions cannot be logged before submitting, but given that conditions can change based on these values, it's probably for the better.
- Lowercase Pi conditions all used the BatteryHolder condition. They should now all match the manual.
- The Lowercase Lambda rule previously could have failed if it was assigned prior to other letters on the module. Now the Lowercase Lambda rule will be assigned separately if the condition has been met at the end of the for statement.

- Removed some calls to GetComponent<TextMesh>() and KMBombInfo queries. 
- Add a Twitch Autosolver