### PR TITLE
Fix lowercase gamma condition

### DIFF
--- a/Assets/greekLetterGridsScript.cs
+++ b/Assets/greekLetterGridsScript.cs
@@ -500,7 +500,7 @@ public class greekLetterGridsScript : MonoBehaviour
                         }
                     }
                     //Otherwise, if the last digit of the serial number is prime...
-                    else if (primeNumbers.ToString().Contains(serialNumberLastChar))
+                    else if (primeNumbers.Contains(serialNumberLastChar))
                     {
                         lettersCorrect[i] = "D3";
                         DebugLog("LOWERCASE GAMMA CONDITION: #4 (last digit of the serial number is prime)");


### PR DESCRIPTION
primeNumbers.ToString() returns `System.String[]` instead of `2, 3, 5, 7`
This has apparently always been the case and we just didn't find out until now.